### PR TITLE
test(bridge): tests for BridgeOutInitiated + bytes32 X-only dest + Y parity

### DIFF
--- a/project/bridge-test-realignment/Milestone-00/Epic-01/overview/e1-fix-gas-test-bridgeout.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-01/overview/e1-fix-gas-test-bridgeout.md
@@ -1,0 +1,51 @@
+# Epic 1 — Fix Gas-Test bridgeOut (M0-E1)
+
+> **Parent milestone:** [Milestone 1 — Green Baseline (M0)](../../overview/milestone-01-green-baseline.md)
+> **Maps to:** [project-plan §5 M0-E1](../../../bridge-test-realignment-project-plan.md)
+> **Owner:** Engineer · **Impact/blast radius:** Test-only; 5 failing Hardhat gas cases · **Estimated effort:** S (≈30–60 min)
+> **Status:** 📋 ready for `/create-prd`
+
+## Objective
+
+Restore the 5 failing gas-comparison cases by updating the stale 3-arg `bridgeOut` call to
+the current 5-arg signature. The gas test exists to track per-operation gas across bin
+counts (6/12/24/48/96); it can't run while ethers fails to resolve the `bridgeOut`
+fragment. This epic only repairs the call site — it does not deepen assertions (that is
+M1).
+
+## Acceptance criteria
+
+- [ ] [withdraw-limiter-gas-comparison.test.ts:205](../../../../../test/gas/withdraw-limiter-gas-comparison.test.ts#L205) calls `bridgeOut(amount, GNUS_TOKEN_ID, destChainID, sgnsDestination, destinationYOdd)`.
+- [ ] Destination args come from the shared fixture (M0-E3), not new inline literals.
+- [ ] All bin-count variants (6, 12, 24, 48, 96) pass and record a gas value.
+- [ ] No change to gas-recording logic or thresholds beyond the call signature.
+- [ ] `npx hardhat test` shows these 5 cases passing; total Hardhat failures drop by 5.
+
+## Tasks
+
+| # | Task | Owner | Done when |
+|---|---|---|---|
+| 1 | Import `SGNS_DESTINATION`, `SGNS_DESTINATION_Y_ODD`, `GNUS_TOKEN_ID`, canonical `destChainID` from the shared fixture (E3) | Engineer | imports resolve; no inline duplicates |
+| 2 | Update the `bridgeOut(...)` call at line ~205 to the 5-arg form | Engineer | call matches contract ABI |
+| 3 | Run the gas suite for all bin counts | Engineer | 5 cases green, gas recorded |
+| 4 | Grep the file for any other stale 3-arg `bridgeOut` references | Engineer | none remain |
+
+## Dependencies & owner gates
+
+- **Upstream:** M0-E3 (shared-bridge-fixtures) should land first so step 1 imports rather
+  than re-declares constants. If E3 is not yet ready, use the same literal values as
+  `GNUSBridgeEnhanced.test.ts` temporarily and refactor when E3 lands.
+- **Owner gates:** none. Fully agent-executable.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Inline literals re-introduced, re-creating drift | Pull from E3 fixture; grep for stray literals |
+| Gas value shifts vs prior baseline confuse readers | This is a signature fix; note that the 5-arg call's gas is the new baseline |
+
+## Notes
+
+- Reference implementation for the exact call shape already exists at
+  [GNUSBridgeEnhanced.test.ts:413](../../../../../test/unit/GNUSBridgeEnhanced.test.ts#L413).
+- Reversible: test-only, single file. Contract code stays untouched.

--- a/project/bridge-test-realignment/Milestone-00/Epic-01/prd-e1-fix-gas-test-bridgeout.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-01/prd-e1-fix-gas-test-bridgeout.md
@@ -1,0 +1,73 @@
+# PRD — Fix Gas-Test bridgeOut (M0-E1)
+
+> **Epic:** [e1-fix-gas-test-bridgeout](./overview/e1-fix-gas-test-bridgeout.md) ·
+> **Milestone:** [M0 — Green Baseline](../overview/milestone-01-green-baseline.md) ·
+> **Plan:** [project-plan §5 M0-E1](../../bridge-test-realignment-project-plan.md)
+> **Status:** 📋 ready for `/generate-tasks` · **Author:** Am0rfu5 · **Date:** 2026-06-19
+
+## 1. Introduction / Overview
+
+The gas-comparison test that measures `bridgeOut` gas across bin counts (6/12/24/48/96)
+still calls `bridgeOut` with the **old 3 arguments** `(amount, id, destChainID)`. The
+contract's `bridgeOut` now takes **5 arguments** — it added `bytes32 sgnsDestination` and
+`bool destinationYOdd`. Because ethers v6 can't find a matching function fragment for the
+3-arg call, all 5 bin-count cases throw before any gas is measured.
+
+This feature updates that single call site to the current 5-argument signature so the gas
+measurement runs again. It is a **test-only** change; it does not alter contract code and
+does not add new assertions (deeper bridge assertions are milestone M1).
+
+## 2. Goals
+
+- **G1** — The gas test calls `bridgeOut` with the current 5-argument signature.
+- **G2** — All five bin-count cases run and record a gas value.
+- **G3** — The 5 corresponding Hardhat failures are eliminated.
+- **G4** — Destination arguments come from the shared fixture (M0-E3), not new inline literals.
+
+## 3. User Stories
+
+- **As a developer tracking gas,** I want the `bridgeOut` gas case to run, so I can compare
+  its cost across bin counts again instead of seeing a fragment error.
+- **As a maintainer,** I want this call site to use the shared bridge fixture, so the next
+  signature change doesn't silently break it again.
+
+## 4. Functional Requirements
+
+1. The system must update the `bridgeOut(...)` call at
+   [withdraw-limiter-gas-comparison.test.ts:205](../../../../../test/gas/withdraw-limiter-gas-comparison.test.ts#L205)
+   to pass five arguments: `(amount, GNUS_TOKEN_ID, DEST_CHAIN_ID, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD)`.
+2. The destination arguments (`SGNS_DESTINATION`, `SGNS_DESTINATION_Y_ODD`) and
+   `DEST_CHAIN_ID` must be imported from `test/utils/bridge-fixtures.ts` (M0-E3), not
+   redefined inline.
+3. The system must not change the gas-recording logic, thresholds, or the `recordGas(...)`
+   call beyond what the new signature requires.
+4. All five bin-count variants (6, 12, 24, 48, 96) must pass and record a gas value.
+5. The file must contain no remaining 3-argument `bridgeOut` calls.
+
+## 5. Non-Goals (Out of Scope)
+
+- Adding event assertions or guard/revert coverage for `bridgeOut` (milestone M1).
+- Creating the shared fixture itself (that is M0-E3; this epic only consumes it).
+- Changing gas thresholds or the comparison report format.
+- Any production contract change.
+
+## 6. Technical Considerations
+
+- **Dependency:** M0-E3 must provide `test/utils/bridge-fixtures.ts`. If E1 is implemented
+  before E3 lands, temporarily use the same literal values as `GNUSBridgeEnhanced.test.ts`
+  and refactor to the import when E3 is ready.
+- **Reference shape:** the correct 5-arg call already exists at
+  [GNUSBridgeEnhanced.test.ts:413](../../../../../test/unit/GNUSBridgeEnhanced.test.ts#L413).
+- **Same-chain guard:** `DEST_CHAIN_ID = 137` is safe — `bridgeOut` reverts only when the
+  destination equals the local chain id.
+
+## 7. Success Metrics
+
+- `npx hardhat test` shows the 5 `GNUSBridge.bridgeOut()` gas cases passing; total Hardhat
+  failures drop by exactly 5.
+- No inline bridge literals remain in the gas test file.
+
+## 8. Open Questions
+
+- None. (If E3 is not yet merged when this is implemented, see the Technical Considerations
+  fallback.)

--- a/project/bridge-test-realignment/Milestone-00/Epic-01/tasks-e1-fix-gas-test-bridgeout.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-01/tasks-e1-fix-gas-test-bridgeout.md
@@ -1,0 +1,40 @@
+# Tasks — Fix Gas-Test bridgeOut (M0-E1)
+
+> **PRD:** [prd-e1-fix-gas-test-bridgeout](./prd-e1-fix-gas-test-bridgeout.md) ·
+> **Epic:** [e1-fix-gas-test-bridgeout](./overview/e1-fix-gas-test-bridgeout.md) ·
+> **Milestone:** [M0 — Green Baseline](../overview/milestone-01-green-baseline.md)
+
+## Relevant Files
+
+- `test/gas/withdraw-limiter-gas-comparison.test.ts` - The gas test whose `bridgeOut` call (line ~205) still uses the old 3-arg signature; the only file edited by this epic.
+- `test/utils/bridge-fixtures.ts` - Shared fixture (from M0-E3) providing `SGNS_DESTINATION`, `SGNS_DESTINATION_Y_ODD`, `DEST_CHAIN_ID`; consumed here.
+- `test/unit/GNUSBridgeEnhanced.test.ts` - Reference for the correct 5-arg call shape (not edited).
+
+### Notes
+
+- This is a Solidity (Diamond/ERC-2535) repo: Hardhat tests under `test/unit`/`test/integration`/`test/gas`; shared TS helpers under `test/utils`.
+- The M0-E3 fixtures are already committed on branch `chore/shared-bridge-fixtures`; branch E1 off it so the import resolves.
+- Run `yarn test` (Hardhat). Foundry is unaffected by this epic.
+- Baseline to beat (no regression): Hardhat **366 passing / 2 pending / 5 failing** — this epic should turn the 5 failures into passes (→ ~371 passing / 0 of these failing).
+
+## Tasks
+
+- [x] 0.0 Create feature branch
+  - [x] 0.1 From `chore/shared-bridge-fixtures` (which carries the M0-E3 fixtures), create and checkout `git checkout -b chore/fix-gas-test-bridgeout`
+  - [x] 0.2 Record the starting count from the last run for reference: Hardhat **366 passing / 2 pending / 5 failing** (the 5 failures are the `GNUSBridge.bridgeOut()` gas cases this epic fixes)
+
+- [x] 1.0 Update the gas-test `bridgeOut` call to the 5-argument signature via the shared fixture
+  - [x] 1.1 In `test/gas/withdraw-limiter-gas-comparison.test.ts`, add an import of `SGNS_DESTINATION`, `SGNS_DESTINATION_Y_ODD`, and `DEST_CHAIN_ID` from `../utils/bridge-fixtures`
+  - [x] 1.2 Update the `bridgeOut(...)` call (~line 205) to `bridgeOut(gnusAmount, GNUS_TOKEN_ID, DEST_CHAIN_ID, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD)`
+  - [x] 1.3 Left the file's local `const GNUS_TOKEN_ID = 0` (line 46) unchanged (number; used as `createNFT` parent arg)
+  - [x] 1.4 Did not change `recordGas(...)`, thresholds, or the report format
+
+- [x] 2.0 Verify the five bin-count gas cases pass and no stale 3-arg literals remain
+  - [x] 2.1 `npx hardhat test test/gas/withdraw-limiter-gas-comparison.test.ts` → all five `GNUSBridge.bridgeOut()` cases pass; **50 passing, 0 failing** in the file
+  - [x] 2.2 Grep found no 3-arg `bridgeOut(` call and no bare `137` destination literal (only a doc-comment mention of `bridgeOut()` on line 8)
+  - [x] 2.3 No `no matching fragment ... key: "bridgeOut"` error in the run
+
+- [ ] 3.0 Verify full-suite no-regression and commit
+  - [ ] 3.1 Run `yarn test` (Hardhat) — confirm the 5 prior failures are gone and pass count rose by ~5 (≈371 passing / 2 pending / 0 of these failing), with no new failures
+  - [ ] 3.2 Confirm no production contract or `scripts/common` change (only the gas test edited)
+  - [ ] 3.3 Stage only `test/gas/withdraw-limiter-gas-comparison.test.ts` + this task file (exclude the owner-gated submodule pointer and unrelated files), then commit on `chore/fix-gas-test-bridgeout` referencing M0-E1 (no merge — owner gate). Body lines ≤ 100 chars (commitlint)

--- a/project/bridge-test-realignment/Milestone-00/Epic-02/CHANGELOG.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-02/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog — Epic M0-E2 (retire-openescrow-test)
+
+## 2026-06-19 — Replaced the commented-out OpenEscrow test with an escrow-free equivalent
+
+**What changed**
+- Removed the commented-out `should maintain contract state across ownership transfer` block in `test/unit/GeniusOwnershipFacet.test.ts` that depended on the removed escrow function.
+- Added an active test asserting that persistent state survives `transferOwnership` without escrow:
+  - mints a GNUS balance to `user1` and grants `MINTER_ROLE` to `user2`,
+  - transfers ownership to `user1`,
+  - asserts the balance and the role assignment are both unchanged afterwards.
+- Reworded the explanatory comment so no `OpenEscrow`/`GeniusAI` text remains anywhere in the file.
+
+**Result**
+- Hardhat: **371 passing / 2 pending / 0 failing → 372 passing / 2 pending / 0 failing** (one new active test; no commented/skipped tests remain).
+- Foundry untouched. No production contract or `scripts/` changes.
+
+**Notes**
+- Coverage is arguably stronger than the original: it checks two independent kinds of persisted state (a token balance and an AccessControl role), meaningful because the diamond `owner` is separate from AccessControl roles.

--- a/project/bridge-test-realignment/Milestone-00/Epic-02/overview/e2-retire-openescrow-test.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-02/overview/e2-retire-openescrow-test.md
@@ -1,0 +1,52 @@
+# Epic 2 — Retire OpenEscrow Test (M0-E2)
+
+> **Parent milestone:** [Milestone 1 — Green Baseline (M0)](../../overview/milestone-01-green-baseline.md)
+> **Maps to:** [project-plan §5 M0-E2](../../../bridge-test-realignment-project-plan.md)
+> **Owner:** Engineer (with Owner ruling if delete-vs-rewrite is ambiguous) · **Impact/blast radius:** Test-only; 1 ownership test · **Estimated effort:** S (≈30 min)
+> **Status:** 📋 ready for `/create-prd`
+
+## Objective
+
+Resolve the orphaned `GeniusOwnershipFacet` test that referenced the removed `OpenEscrow`
+function. It is currently **commented out** in the working tree — green, but as
+undocumented debt. The original intent was to prove contract state survives an ownership
+transfer; `OpenEscrow` was merely the vehicle for creating that state. This epic
+re-expresses the intent without escrow, or deletes the test with a recorded reason, so no
+commented-out block remains.
+
+## Acceptance criteria
+
+- [ ] The commented block at [GeniusOwnershipFacet.test.ts:259-276](../../../../../test/unit/GeniusOwnershipFacet.test.ts#L259-L276) is gone.
+- [ ] Either: an active test asserts state survives `transferOwnership` **without** `OpenEscrow` (e.g. mint a balance / set a role, transfer ownership, assert it's unchanged); **or** the test is deleted with a one-line `// removed: …` reason in the suite or commit message.
+- [ ] No `OpenEscrow` or `GeniusAI` reference survives in this file — including comments.
+- [ ] `npx hardhat test` shows the `GeniusOwnershipFacet` suite green; no new pending/skip introduced.
+
+## Tasks
+
+| # | Task | Owner | Done when |
+|---|---|---|---|
+| 1 | Decide rewrite-vs-delete (default: rewrite escrow-free to preserve intent) | Engineer (Owner if ambiguous) | decision recorded |
+| 2 | If rewrite: implement an escrow-free state-persistence assertion across `transferOwnership` | Engineer | test runs and passes |
+| 3 | If delete: remove the block and record the reason | Engineer | no orphaned comment remains |
+| 4 | grep the file (and suite) for residual `OpenEscrow`/`GeniusAI` text | Engineer | none remain |
+
+## Dependencies & owner gates
+
+- **Upstream:** none (independent of E1/E3/E4; can run in parallel).
+- **Owner gate (conditional, blocking):** if no meaningful escrow-free state-persistence
+  assertion is reasonable, the **Owner** rules on delete-vs-rewrite before closing. Note:
+  the broader "`OpenEscrow` selector is absent from the diamond" negative test is **M2-E1**,
+  not this epic.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Rewrite changes what's being verified vs original intent | Keep the assertion about *state persistence across ownership transfer*; only swap the state-creation vehicle |
+| Residual `OpenEscrow` text left in a comment | grep sweep as exit check |
+
+## Notes
+
+- Reversible: test-only, single file.
+- Scope boundary: this epic removes the *reference*; proving the *selector is gone from the
+  diamond* belongs to M2-E1.

--- a/project/bridge-test-realignment/Milestone-00/Epic-02/prd-e2-retire-openescrow-test.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-02/prd-e2-retire-openescrow-test.md
@@ -1,0 +1,78 @@
+# PRD — Retire OpenEscrow Test (M0-E2)
+
+> **Epic:** [e2-retire-openescrow-test](./overview/e2-retire-openescrow-test.md) ·
+> **Milestone:** [M0 — Green Baseline](../overview/milestone-01-green-baseline.md) ·
+> **Plan:** [project-plan §5 M0-E2](../../bridge-test-realignment-project-plan.md)
+> **Status:** 📋 ready for `/generate-tasks` · **Author:** Am0rfu5 · **Date:** 2026-06-19
+
+## 1. Introduction / Overview
+
+The `GeniusAI` contract — which provided the `OpenEscrow` payable function — was removed
+from the diamond. One `GeniusOwnershipFacet` test, "should maintain contract state across
+ownership transfer," used `OpenEscrow` to create on-contract state, then checked the state
+survived a `transferOwnership`. With `OpenEscrow` gone, the test was **commented out** to
+keep the suite green — leaving an undocumented commented block.
+
+This feature **rewrites that test escrow-free** so the original intent — *contract state
+persists across an ownership transfer* — is still verified, without depending on the
+removed escrow feature. It is a test-only change.
+
+## 2. Goals
+
+- **G1** — The commented-out `OpenEscrow` test block is removed.
+- **G2** — An **active** test verifies that contract state persists across `transferOwnership`,
+  using state that still exists after the GeniusAI removal (token balances and/or roles).
+- **G3** — No reference to `OpenEscrow` or `GeniusAI` remains in the file, including comments.
+- **G4** — No new pending/skipped test is introduced.
+
+## 3. User Stories
+
+- **As a maintainer,** I want the ownership-transfer test to verify real, current state, so
+  I keep coverage of "ownership transfer doesn't disturb contract state" without the dead
+  escrow dependency.
+- **As a reviewer,** I want no commented-out test blocks, so the suite reflects exactly
+  what is and isn't tested.
+
+## 4. Functional Requirements
+
+1. The system must delete the commented-out block at
+   [GeniusOwnershipFacet.test.ts:259-276](../../../../../test/unit/GeniusOwnershipFacet.test.ts#L259-L276).
+2. The system must add an active test in the `Edge Cases` describe block that:
+   1. establishes observable contract state **without** `OpenEscrow` — e.g. mint a GNUS
+      balance to an account and/or grant a role to an account;
+   2. records that state before the transfer;
+   3. calls `transferOwnership` (the path already exercised by neighboring tests);
+   4. asserts the recorded state (balance and/or role assignment) is **unchanged** after
+      the transfer.
+3. The test must use only functions that exist on the current diamond (e.g. `mint`,
+   `balanceOf`, `grantRole`/`hasRole`, `transferOwnership`, `owner`).
+4. The file must contain no `OpenEscrow` or `GeniusAI` text after the change (verified by grep).
+5. The `GeniusOwnershipFacet` suite must pass under `npx hardhat test` with no new skips.
+
+## 5. Non-Goals (Out of Scope)
+
+- Asserting that the `OpenEscrow` **selector is absent from the diamond** — that negative
+  test belongs to milestone M2 (M2-E1).
+- Any change to ownership or access-control contract logic.
+- Re-introducing escrow functionality in any form.
+
+## 6. Technical Considerations
+
+- **State vehicle:** prefer a GNUS balance (`mint` then `balanceOf`) and/or a role
+  (`grantRole` then `hasRole`) as the persisted state, since those clearly survive an
+  ownership transfer and use existing facets.
+- **Intent fidelity:** keep the assertion focused on *state persistence across ownership
+  transfer*; only the mechanism for creating state changes (no escrow).
+- **Existing patterns:** neighboring tests in the same file already use
+  `transferOwnership`, `owner()`, and signer connections — follow their style.
+
+## 7. Success Metrics
+
+- The `GeniusOwnershipFacet` suite is green with one **active** state-persistence test (not
+  commented, not skipped).
+- `grep -n "OpenEscrow\|GeniusAI"` on the file returns nothing.
+
+## 8. Open Questions
+
+- Which state vehicle to assert — balance, role, or both? *Default: assert both a minted
+  GNUS balance and a granted role for stronger coverage.* Resolve during `/generate-tasks`.

--- a/project/bridge-test-realignment/Milestone-00/Epic-02/tasks-e2-retire-openescrow-test.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-02/tasks-e2-retire-openescrow-test.md
@@ -1,0 +1,47 @@
+# Tasks — Retire OpenEscrow Test (M0-E2)
+
+> **PRD:** [prd-e2-retire-openescrow-test](./prd-e2-retire-openescrow-test.md) ·
+> **Epic:** [e2-retire-openescrow-test](./overview/e2-retire-openescrow-test.md) ·
+> **Milestone:** [M0 — Green Baseline](../overview/milestone-01-green-baseline.md)
+
+## Relevant Files & Resources
+
+- `test/unit/GeniusOwnershipFacet.test.ts` - **Modified.** Commented-out `OpenEscrow` test replaced with an active escrow-free state-persistence test (balance + role survive `transferOwnership`).
+- `…/Epic-02/CHANGELOG.md` - **Created.** Epic change log.
+- Hardhat only — this epic does not touch Foundry or `anvil`.
+
+### Notes
+
+- Reversible, test-only change; rollback = `git revert` the commit.
+- The diamond `owner` (LibDiamond `contractOwner`) is separate from AccessControl roles, so both a token balance and a granted role should persist across `transferOwnership` — that is what the new test asserts.
+- `owner` (signer 0) is the deployer/super-admin and already holds `MINTER_ROLE` (used to `mint`) and role-admin rights (used to `grantRole`).
+- Baseline to beat (no regression): Hardhat **371 passing / 2 pending / 0 failing**; the new active test should make it **372 passing**. Foundry untouched.
+- Exit-criterion for M0: **no** `OpenEscrow`/`GeniusAI` text remains (not even in comments) and no new skipped/commented test.
+
+## Tasks
+
+- [x] 0.0 Prepare & safeguard
+  - [x] 0.1 Created and checked out `chore/retire-openescrow-test` off `chore/fix-foundry-fuzz-bridgeout`
+  - [x] 0.2 Baseline: **371 passing / 2 pending / 0 failing**; file carried the commented-out `OpenEscrow` block
+
+- [x] 1.0 Replace the commented-out `OpenEscrow` test with an escrow-free state-persistence test
+  - [x] 1.1 Deleted the commented-out block (~lines 259-276)
+  - [x] 1.2 Added active test: mint 100 GNUS to `user1`; `grantRole(MINTER_ROLE, user2)`
+  - [x] 1.3 Recorded pre-transfer balance + asserted `hasRole` true
+  - [x] 1.4 `transferOwnership(user1)`; asserted `owner()` == `user1`
+  - [x] 1.5 Asserted balance unchanged and role still held after transfer
+  - [x] 1.6 Self-contained (suite `afterEach` reverts snapshot)
+
+- [x] 2.0 Verify no `OpenEscrow`/`GeniusAI` references remain
+  - [x] 2.1 `grep` → no matches (reworded my own comment to avoid the literal tokens)
+  - [x] 2.2 No commented-out / `.skip` / `xit` tests in the file
+
+- [x] 3.0 Validate the change
+  - [x] 3.1 `npx hardhat test test/unit/GeniusOwnershipFacet.test.ts` → new test passes; **19 passing**
+  - [x] 3.2 `yarn test` → **372 passing / 2 pending / 0 failing** (was 371/2/0); no new failures
+  - [x] 3.3 No production contract or `scripts/` change (only the test file edited)
+
+- [x] 4.0 Record the change and commit
+  - [x] 4.1 Appended summary to `…/Epic-02/CHANGELOG.md`
+  - [x] 4.2 Updated results + Relevant Files
+  - [x] 4.3 Staged only the test file + task file + CHANGELOG; committed on `chore/retire-openescrow-test`

--- a/project/bridge-test-realignment/Milestone-00/Epic-03/overview/e3-shared-bridge-fixtures.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-03/overview/e3-shared-bridge-fixtures.md
@@ -1,0 +1,56 @@
+# Epic 3 — Shared Bridge Fixtures (M0-E3)
+
+> **Parent milestone:** [Milestone 1 — Green Baseline (M0)](../../overview/milestone-01-green-baseline.md)
+> **Maps to:** [project-plan §5 M0-E3](../../../bridge-test-realignment-project-plan.md)
+> **Owner:** Engineer · **Impact/blast radius:** Test-only; multiple bridge specs + Foundry base · **Estimated effort:** M (≈1–2 h)
+> **Status:** 📋 ready for `/create-prd`
+
+## Objective
+
+Root-cause fix for the drift this whole project is cleaning up. Bridge test constants are
+currently redefined per file — which is exactly why `GNUSBridgeEnhanced.test.ts` got the
+new 5-arg shape while the gas test (E1) and the Foundry fuzz suite (E4) were left on stale
+signatures. This epic establishes **one shared fixture per runner** so a future signature
+change is a single-file edit, not a scavenger hunt.
+
+## Acceptance criteria
+
+- [ ] A Hardhat/TS fixture module exports `SGNS_DESTINATION` (`bytes32` X), `SGNS_DESTINATION_Y_ODD` (`bool`), canonical `destChainID`, and `GNUS_TOKEN_ID`.
+- [ ] The Foundry test base ([GeniusDiamondTestBase.sol:18](../../../../../test/foundry/base/GeniusDiamondTestBase.sol#L18)) exposes a matching `bytes32` X constant + `bool` Y-parity, **replacing** the 64-byte `bytes TEST_SGNS_DEST`.
+- [ ] Values are byte-for-byte identical to those in the currently-passing `GNUSBridgeEnhanced.test.ts` so no passing test changes behavior.
+- [ ] `GNUSBridgeEnhanced.test.ts` (and any other bridge spec with inline literals) imports from the shared module.
+- [ ] A grep finds no duplicate inline `SGNS_DESTINATION`/`zeroPadValue('0x1234', 32)`/`TEST_SGNS_DEST` literals outside the fixtures.
+- [ ] Full Hardhat + Foundry suites pass after refactor (no regressions vs pre-refactor counts).
+
+## Tasks
+
+| # | Task | Owner | Done when |
+|---|---|---|---|
+| 1 | Choose fixture locations (e.g. `test/utils/` for TS; constants on the Foundry base) consistent with repo conventions | Engineer | paths agreed, conventions matched |
+| 2 | Create the TS fixture exporting the four constants | Engineer | module compiles, exports resolve |
+| 3 | Replace `bytes TEST_SGNS_DEST` in the Foundry base with `bytes32` X + `bool` Y-parity | Engineer | base compiles; consumers updated |
+| 4 | Refactor `GNUSBridgeEnhanced.test.ts` to import the TS fixture | Engineer | no inline literals; test green |
+| 5 | grep sweep across `test/` for residual literals | Engineer | none outside fixtures |
+| 6 | Run both suites to confirm no regression | Engineer | counts ≥ pre-refactor pass counts |
+
+## Dependencies & owner gates
+
+- **Upstream:** none. **This epic should land first within M0** so E1 and E4 import from it.
+- **Downstream:** E1 (Hardhat gas) and E4 (Foundry fuzz) consume these fixtures.
+- **Owner gates:** none. Agent-executable. (Foundry steps still need `anvil` to *verify*
+  via E4, but E3 itself is just compile + refactor.)
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| A copied value differs subtly and breaks a passing test | Copy verbatim from `GNUSBridgeEnhanced.test.ts`; diff pass counts before/after |
+| TS and Foundry fixtures drift from each other | Keep the X value identical across both; document the pairing in the fixture comment |
+| Over-refactoring unrelated constants | Scope strictly to the four bridge constants |
+
+## Notes
+
+- Reversible: test-only.
+- This is the durable defense against the exact failure class M0 is fixing — prioritize
+  clarity of the single source of truth over breadth.
+- Cross-reference: design doc [§5 source-of-truth & fixtures](../../../bridge-test-realignment-architecture.md).

--- a/project/bridge-test-realignment/Milestone-00/Epic-03/prd-e3-shared-bridge-fixtures.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-03/prd-e3-shared-bridge-fixtures.md
@@ -1,0 +1,135 @@
+# PRD — Shared Bridge Test Fixtures (M0-E3)
+
+> **Epic:** [e3-shared-bridge-fixtures](./overview/e3-shared-bridge-fixtures.md) ·
+> **Milestone:** [M0 — Green Baseline](../overview/milestone-01-green-baseline.md) ·
+> **Plan:** [project-plan §5 M0-E3](../../bridge-test-realignment-project-plan.md)
+> **Status:** 📋 ready for `/generate-tasks` · **Author:** Am0rfu5 · **Date:** 2026-06-19
+
+## 1. Introduction / Overview
+
+The GNUS test suite has the same bridge constants — the SuperGenius (SGNS) destination
+key, its Y-parity, the destination chain id, and the GNUS token id — **copy-pasted into
+multiple test files**. When the `bridgeOut` contract signature changed, only one file
+(`GNUSBridgeEnhanced.test.ts`) was updated; the Hardhat gas test and the Foundry fuzz
+suite were left behind on stale signatures and broke. That divergence is the root cause of
+this whole milestone's failures.
+
+This feature creates **one shared source of truth per test runner** for bridge constants:
+a TypeScript fixture for Hardhat tests and a constants block on the Foundry test base. From
+then on, a bridge signature or value change is a **single-file edit**, not a hunt across
+the suite.
+
+This is a **test-infrastructure** change. It touches no production contract code and
+changes no test's behavior — only where its constants come from.
+
+## 2. Goals
+
+- **G1** — A single TypeScript module exports every bridge constant Hardhat tests need.
+- **G2** — The Foundry test base exposes the matching constants in the new
+  `bytes32` + `bool` shape, replacing the obsolete 64-byte `bytes` destination.
+- **G3** — Constant values are **identical** to those in today's passing tests, so no test
+  changes behavior as a result of this refactor (zero regressions).
+- **G4** — The three known bridge test sites import from the shared fixtures with **no
+  inline duplicate literals** remaining.
+- **G5** — A future signature/value change requires editing **one file per runner**.
+
+## 3. User Stories
+
+- **As a developer changing the bridge interface,** I want to update the destination key
+  or chain id in one place per runner, so a future change can't silently leave some tests
+  on a stale signature.
+- **As a developer writing a new bridge test,** I want to `import` the canonical fixtures,
+  so I don't copy stale literals from another file.
+- **As a reviewer,** I want a single, documented definition of `SGNS_DESTINATION` /
+  `destChainID`, so I can verify a test uses the agreed values at a glance.
+
+## 4. Functional Requirements
+
+**TypeScript fixture (Hardhat)**
+
+1. The system must provide a new file `test/utils/bridge-fixtures.ts`.
+2. It must export `SGNS_DESTINATION` — the 32-byte (`bytes32`) X component of the SGNS
+   destination key — with the **same value** currently used in `GNUSBridgeEnhanced.test.ts`
+   (`ethers.zeroPadValue('0x1234', 32)`).
+3. It must export `SGNS_DESTINATION_Y_ODD` — the boolean Y-parity — with the current value
+   (`false`).
+4. It must export `DEST_CHAIN_ID = 137` (Polygon) as the single canonical destination chain
+   id for both runners. (137 is guaranteed `!=` the local Hardhat/anvil chain id, so
+   `bridgeOut`'s same-chain guard is satisfied.)
+5. It must **re-export** `GNUS_TOKEN_ID` from `scripts/common` so bridge specs get all four
+   constants from one import. It must **not** redefine `GNUS_TOKEN_ID` with a new literal.
+
+**Foundry fixture (base contract)**
+
+6. The system must add to `test/foundry/base/GeniusDiamondTestBase.sol` a `bytes32` constant
+   holding the **same** X value as the TS `SGNS_DESTINATION`, and a `bool` constant for the
+   Y-parity (matching `SGNS_DESTINATION_Y_ODD`).
+7. The system must **remove** the obsolete 64-byte `bytes public constant TEST_SGNS_DEST`
+   once its consumers are migrated (consumer migration itself is M0-E4; this epic provides
+   the replacement constants and removes `TEST_SGNS_DEST` when nothing references it).
+8. The Foundry constants must carry a comment pairing them with the TS fixture so the two
+   cannot silently drift.
+
+**Refactor of known sites**
+
+9. The system must update `GNUSBridgeEnhanced.test.ts` to import `SGNS_DESTINATION`,
+   `SGNS_DESTINATION_Y_ODD`, and `DEST_CHAIN_ID` from `test/utils/bridge-fixtures.ts`,
+   removing its inline definitions.
+10. The scope of refactor is the **three known bridge sites only**: the gas test
+    (`test/gas/withdraw-limiter-gas-comparison.test.ts`), `GNUSBridgeEnhanced.test.ts`, and
+    the Foundry suite (`BridgeFuzz.t.sol` + base). Unrelated files must not be touched.
+    *(Wiring the gas test and Foundry fuzz to the fixtures is completed in M0-E1 and M0-E4
+    respectively; this epic must leave the fixtures ready and migrate `GNUSBridgeEnhanced`.)*
+
+**Verification**
+
+11. After the refactor, a search of the three known sites must find no inline
+    `zeroPadValue('0x1234', 32)`, `SGNS_DESTINATION` literal, or `TEST_SGNS_DEST` definition
+    outside the fixtures.
+12. The full Hardhat suite (`npx hardhat test`) and Foundry suite
+    (`yarn clean-compile && yarn forge:test` against a running `anvil`) must pass with pass
+    counts **no lower** than before this epic.
+
+## 5. Non-Goals (Out of Scope)
+
+- Fixing the failing gas test call site (M0-E1) or the Foundry fuzz selectors/assertions
+  (M0-E4) — this epic only provides the fixtures and migrates `GNUSBridgeEnhanced.test.ts`.
+- Deepened conformance assertions — full 7-field event matching, destination-key edge
+  cases, guard-reason coverage (M1).
+- A repo-wide grep sweep of every test file for any bridge-ish literal (explicitly
+  declined; known sites only).
+- Any change to production contracts or to `scripts/common`'s `GNUS_TOKEN_ID` value.
+- Standardizing non-bridge constants (roles, supply, actors) already on the Foundry base.
+
+## 6. Technical Considerations
+
+- **Existing source of truth:** `GNUS_TOKEN_ID` already lives in `scripts/common` (imported
+  by `test/unit/NFTFactory.test.ts`). Re-export it — do not fork the value.
+- **TS home:** `test/utils/` already holds `logger.ts`, `network-utils.ts`,
+  `test-template.ts`; `bridge-fixtures.ts` fits the convention.
+- **Foundry home:** `GeniusDiamondTestBase.sol` already centralizes role/token constants;
+  add the bridge constants to that same block.
+- **Value fidelity:** copy `SGNS_DESTINATION` / Y-parity verbatim from
+  `GNUSBridgeEnhanced.test.ts` (the currently-passing reference) to avoid behavior drift.
+- **Same-chain guard:** `bridgeOut` reverts when `destChainID == local chainID`; `137` is
+  safe for both Hardhat and anvil local chains.
+- **Cross-runner pairing:** the TS `bytes32` and the Foundry `bytes32` must encode the same
+  X value; document the pairing so future edits keep them in lockstep.
+
+## 7. Success Metrics
+
+- **One import** brings all four bridge constants into a Hardhat spec (verified in
+  `GNUSBridgeEnhanced.test.ts`).
+- **Zero** inline bridge-constant duplicates remain across the three known sites.
+- **Zero** test-behavior regressions: Hardhat and Foundry pass counts ≥ pre-epic counts.
+- A simulated future signature change is expressible as a **single-file edit per runner**
+  (demonstrated conceptually, not committed).
+
+## 8. Open Questions
+
+- Exact export style for the TS module (named consts vs a single `BRIDGE_FIXTURES` object)?
+  *Default: individual named exports, matching how the constants are consumed today.* —
+  defer to `/generate-tasks`.
+- Should `DEST_CHAIN_ID` be typed as `number` or `bigint` for ethers v6 call ergonomics?
+  *Default: match what the existing passing call sites pass (number literal `137`).* —
+  resolve during implementation.

--- a/project/bridge-test-realignment/Milestone-00/Epic-03/tasks-e3-shared-bridge-fixtures.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-03/tasks-e3-shared-bridge-fixtures.md
@@ -1,0 +1,66 @@
+# Tasks — Shared Bridge Test Fixtures (M0-E3)
+
+> **PRD:** [prd-e3-shared-bridge-fixtures](./prd-e3-shared-bridge-fixtures.md) ·
+> **Epic:** [e3-shared-bridge-fixtures](./overview/e3-shared-bridge-fixtures.md) ·
+> **Milestone:** [M0 — Green Baseline](../overview/milestone-01-green-baseline.md)
+
+## Relevant Files
+
+- `test/utils/bridge-fixtures.ts` - **Created.** Single TS source of truth for bridge constants (`SGNS_DESTINATION`, `SGNS_DESTINATION_Y_ODD`, `DEST_CHAIN_ID`) and a re-export of `GNUS_TOKEN_ID`.
+- `scripts/common.ts` - Existing home of `GNUS_TOKEN_ID` (`0n`); re-exported by the new fixture (value unchanged, file not modified).
+- `test/unit/GNUSBridgeEnhanced.test.ts` - **Modified.** Imports from the fixture; inline `SGNS_DESTINATION`/`SGNS_DESTINATION_Y_ODD` consts removed; `137` destChainID literals → `DEST_CHAIN_ID`.
+- `test/foundry/base/GeniusDiamondTestBase.sol` - **Modified.** Added `bytes32 SGNS_DESTINATION` + `bool SGNS_DESTINATION_Y_ODD` (paired with the TS fixture); `TEST_SGNS_DEST` kept + marked deprecated with a `TODO(M0-E4)` (still referenced by `BridgeFuzz.t.sol` and `GeniusDiamondHandler.sol`).
+- `test/gas/withdraw-limiter-gas-comparison.test.ts` - **Not edited here** (wired to the fixture in M0-E1); downstream consumer.
+- `test/foundry/fuzz/BridgeFuzz.t.sol` - **Not edited here** (migrated in M0-E4); downstream consumer.
+- `test/foundry/handlers/GeniusDiamondHandler.sol` - **Not edited here** (discovered consumer of old `bridgeOut(...,bytes)`; migrate in M0-E4).
+
+### Notes
+
+- This is a Solidity (Diamond/ERC-2535) repo: Hardhat tests live under `test/unit`/`test/integration`/`test/gas`; Foundry tests under `test/foundry`; shared TS helpers under `test/utils`.
+- Run `yarn test` (Hardhat) and `yarn forge:test` (Foundry, requires a running **`anvil`**), or `yarn test:all` for both. Run `yarn clean-compile` after changing the Foundry base.
+- **Value fidelity is the core constraint:** copy `SGNS_DESTINATION` / Y-parity verbatim from the currently-passing `GNUSBridgeEnhanced.test.ts` so no test changes behavior.
+- Scope is the **three known bridge sites only** — do not touch unrelated files.
+
+## Tasks
+
+- [x] 0.0 Create feature branch
+  - [x] 0.1 Confirm the current branch is `feature/bridge-out-initiated`, then create and checkout a working branch off it: `git checkout -b chore/shared-bridge-fixtures`
+  - [x] 0.2 Confirm a clean baseline: run `yarn test` and (with `anvil` running) `yarn clean-compile && yarn forge:test`, and record the starting pass/fail/pending counts to compare against later
+        - **Baseline (2026-06-19, branch `chore/shared-bridge-fixtures`):**
+          - Hardhat (`yarn test`): **366 passing, 2 pending, 5 failing** (5 not 6 — E2's OpenEscrow test already commented out in the working tree).
+          - Foundry (`yarn forge:test`, anvil chain 31337): **216 passed, 1 failed, 1 skipped** (the 1 failure is `BridgeFuzz` — owned by M0-E4, not E3).
+        - **Gating note:** baseline is intentionally red (this milestone exists to fix it). E3 is gated on **no regression vs. these counts**, not all-green.
+
+- [x] 1.0 Create the TypeScript bridge fixture module (`test/utils/bridge-fixtures.ts`)
+  - [x] 1.1 Create `test/utils/bridge-fixtures.ts`
+  - [x] 1.2 Import `ethers` and export `SGNS_DESTINATION = ethers.zeroPadValue('0x1234', 32)` — copied verbatim from `GNUSBridgeEnhanced.test.ts` (the 32-byte X component of the SGNS destination key)
+  - [x] 1.3 Export `SGNS_DESTINATION_Y_ODD = false` (the boolean Y-parity, matching the current value)
+  - [x] 1.4 Export `DEST_CHAIN_ID = 137` as the single canonical destination chain id (Polygon; guaranteed `!=` local Hardhat/anvil chain id so the same-chain `bridgeOut` guard passes). Match the literal type used at existing call sites (number)
+  - [x] 1.5 Re-export `GNUS_TOKEN_ID` from `scripts/common` (e.g. `export { GNUS_TOKEN_ID } from '../../scripts/common';`) — do NOT redefine it with a new literal
+  - [x] 1.6 Add a top-of-file comment stating this is the single source of truth for Hardhat bridge constants and that the X value must stay in lockstep with the Foundry base (Task 2.0)
+
+- [x] 2.0 Add matching bridge constants to the Foundry test base (`bytes32` X + `bool` Y-parity)
+  - [x] 2.1 In `test/foundry/base/GeniusDiamondTestBase.sol`, add `bytes32 public constant SGNS_DESTINATION = bytes32(uint256(0x1234));` — the same X value as the TS fixture (`0x1234` left-padded to 32 bytes)
+  - [x] 2.2 Add `bool public constant SGNS_DESTINATION_Y_ODD = false;` matching the TS Y-parity
+  - [x] 2.3 Add a comment pairing these constants with `test/utils/bridge-fixtures.ts` so the two cannot silently drift
+  - [x] 2.4 Do NOT yet delete `TEST_SGNS_DEST` if other Foundry files still reference it (its consumer `BridgeFuzz.t.sol` is migrated in M0-E4); deletion is handled in Task 4.0 once it is unreferenced
+  - [x] 2.5 Run `yarn clean-compile` to confirm the base still compiles
+
+- [x] 3.0 Migrate `GNUSBridgeEnhanced.test.ts` to import from the shared fixture
+  - [x] 3.1 Add an import of `SGNS_DESTINATION`, `SGNS_DESTINATION_Y_ODD`, and `DEST_CHAIN_ID` from `../utils/bridge-fixtures` (file does not use `GNUS_TOKEN_ID`, so not imported)
+  - [x] 3.2 Remove the inline `const SGNS_DESTINATION = ...` and `const SGNS_DESTINATION_Y_ODD = ...` definitions
+  - [x] 3.3 Replace any inline `137` destination-chain literal in `bridgeOut(...)` calls with `DEST_CHAIN_ID` (4 calls + 1 `withArgs`; the `srcChainID` literal `1` left untouched)
+  - [x] 3.4 Run `npx hardhat test test/unit/GNUSBridgeEnhanced.test.ts` and confirm the file's tests still pass unchanged — **31 passing, 0 failing**
+
+- [x] 4.0 Remove obsolete/duplicate literals and verify no drift between runners
+  - [x] 4.1 Confirm `TEST_SGNS_DEST` reference state. **Still referenced** by `test/foundry/fuzz/BridgeFuzz.t.sol` (E4) and `test/foundry/handlers/GeniusDiamondHandler.sol` — so kept, with a `// TODO(M0-E4): remove after BridgeFuzz migration` note added in `GeniusDiamondTestBase.sol`.
+  - [x] 4.2 Grep the migrated site (`GNUSBridgeEnhanced.test.ts`) for leftover inline literals (`zeroPadValue('0x1234', 32)`, standalone `SGNS_DESTINATION =`) — **none remain**. (Gas test + BridgeFuzz still hold their own literals; migrating those is M0-E1 / M0-E4, out of E3 scope.)
+  - [x] 4.3 Verified TS `zeroPadValue('0x1234', 32)` == Foundry `bytes32(uint256(0x1234))` == `0x00…1234` (identical 32-byte X value).
+  - [x] 4.4 Confirmed no production contract or `scripts/common` value changed (`git status` on `contracts/`/`scripts/` shows no tracked changes).
+  - [x] 4.5 **(discovered)** `test/foundry/handlers/GeniusDiamondHandler.sol:275` also calls the old `bridgeOut(...,bytes)` form — out of E3 scope; logged for **M0-E4** to migrate alongside `BridgeFuzz.t.sol` (and only then can `TEST_SGNS_DEST` be deleted).
+
+- [x] 5.0 Verify both suites are green with no regressions
+  - [x] 5.1 `yarn test` (Hardhat) → **366 passing, 2 pending, 5 failing** — identical to baseline, no regression (the 5 failures are the gas test, owned by M0-E1).
+  - [x] 5.2 `yarn clean-compile && yarn forge:test` (Foundry, anvil 31337) → **216 passed, 1 failed, 1 skipped** — identical to baseline; base compiles with the new constants. The 1 failure is `BridgeFuzz::testFuzz_bridgeAmountEdgeCases` (owned by M0-E4). NOTE: `forge:test` requires a fresh `yarn clean-compile` first, else HH701 "multiple artifacts for GeniusDiamond".
+  - [x] 5.3 Final counts recorded here and in the commit message.
+  - [x] 5.4 Commit the change on `chore/shared-bridge-fixtures` referencing M0-E3 (no merge — owner gate).

--- a/project/bridge-test-realignment/Milestone-00/Epic-04/CHANGELOG.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-04/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog — Epic M0-E4 (fix-foundry-fuzz-bridgeout)
+
+## 2026-06-19 — Foundry bridge fuzz migrated to the bytes32+bool signature
+
+**What changed**
+- Added `IGNUSBridgeOut` typed interface + `DEST_CHAIN_ID = 137` to `GeniusDiamondTestBase.sol`; removed the deprecated `TEST_SGNS_DEST` bytes constant.
+- Migrated `BridgeFuzz.t.sol` from the dead `bridgeOut(...,bytes)` selector to `bridgeOut(...,bytes32,bool)` via the typed interface:
+  - `testFuzz_bridgeAmountEdgeCases` now bridges a real valid amount (was failing on a missing selector).
+  - `testFuzz_RevertWhen_depositExceedsBalance` asserts the specific reason `"Insufficient tokens."` (was a false-green).
+  - `testFuzz_bridgeDeposit` asserts the balance is burned and `BridgeOutInitiated` is emitted (was a no-op).
+  - Removed the obsolete `test_RevertWhen_InvalidDestinationKeyLength` (bytes32 is fixed-length).
+- Migrated `GeniusDiamondHandler.handler_bridgeDeposit` to the typed `try/catch` call (success-gated ghost counters preserved); dest chain `1` → `DEST_CHAIN_ID`.
+
+**Result**
+- Foundry: **216 passed / 1 failed / 1 skipped → 216 passed / 0 failed / 1 skipped** (total 218 → 217; −1 obsolete test). `forge:test` exit 0.
+- Hardhat unaffected (test-only Foundry changes): stays 371 passing / 2 pending / 0 failing.
+- No production contract or `scripts/` changes.
+
+**Notes**
+- `yarn forge:test` requires a running `anvil` (chain 31337) and a fresh `yarn clean-compile` (else HH701).
+- The diamond's `chainID` defaults to 0 in tests, so `DEST_CHAIN_ID = 137` satisfies the same-chain guard without `setChainID`.

--- a/project/bridge-test-realignment/Milestone-00/Epic-04/overview/e4-fix-foundry-fuzz-bridgeout.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-04/overview/e4-fix-foundry-fuzz-bridgeout.md
@@ -1,0 +1,62 @@
+# Epic 4 — Fix Foundry Fuzz bridgeOut (M0-E4)
+
+> **Parent milestone:** [Milestone 1 — Green Baseline (M0)](../../overview/milestone-01-green-baseline.md)
+> **Maps to:** [project-plan §5 M0-E4](../../../bridge-test-realignment-project-plan.md)
+> **Owner:** Engineer (Owner provides `anvil` gate) · **Impact/blast radius:** Test-only; Foundry fuzz suite + base · **Estimated effort:** M (≈1–2 h)
+> **Status:** 📋 ready for `/create-prd`
+
+## Objective
+
+Migrate the Foundry bridge fuzz suite from the obsolete `bridgeOut(...,bytes)` selector to
+the current `bridgeOut(uint256,uint256,uint256,bytes32,bool)`. Today every call in
+[BridgeFuzz.t.sol](../../../../../test/foundry/fuzz/BridgeFuzz.t.sol) encodes selector
+`0xf7587f7d`, which no longer exists on the diamond, so `diamond.call(...)` always reverts.
+This both **fails** the edge-case test and produces **false-greens** in the negative tests
+(they pass only because the selector is missing — not because the contract logic rejected
+the input). This epic makes the suite test the real bridge.
+
+## Acceptance criteria
+
+- [ ] All `bridgeOut` calls in `BridgeFuzz.t.sol` use `bridgeOut(uint256,uint256,uint256,bytes32,bool)` via the E3 Foundry fixture.
+- [ ] `testFuzz_bridgeAmountEdgeCases` passes against a **real** bridge call (not a missing selector).
+- [ ] `testFuzz_RevertWhen_depositExceedsBalance` asserts the **specific** insufficient-balance revert, not bare `success == false`.
+- [ ] `testFuzz_bridgeDeposit` gains a meaningful assertion (no more silent no-op pass).
+- [ ] The obsolete `test_RevertWhen_InvalidDestinationKeyLength` is **removed** (a `bytes32` is fixed-length; "wrong length" is unreachable).
+- [ ] `yarn clean-compile && yarn forge:test` (against a running **`anvil`**) reports 0 failing; the previously-failing fuzz test is green for the right reason.
+
+## Tasks
+
+| # | Task | Owner | Done when |
+|---|---|---|---|
+| 1 | Adopt the E3 Foundry `bytes32` X + `bool` Y-parity constants in place of `TEST_SGNS_DEST` | Engineer | base + suite compile |
+| 2 | Migrate every `encodeWithSignature("bridgeOut(...)")` to the 5-param selector | Engineer | calls hit a real facet |
+| 3 | Rewrite `testFuzz_RevertWhen_depositExceedsBalance` to assert the specific revert reason | Engineer | passes for the right reason |
+| 4 | Add a real assertion to `testFuzz_bridgeDeposit` (e.g. balance burned / event emitted) | Engineer | no silent-pass path |
+| 5 | Delete `test_RevertWhen_InvalidDestinationKeyLength` | Engineer | gone; no dead bytes-length logic |
+| 6 | Run `yarn clean-compile && yarn forge:test` against `anvil` | Engineer | 0 failing |
+
+## Dependencies & owner gates
+
+- **Upstream:** M0-E3 (Foundry fixture migration) — step 1 depends on it.
+- **Owner gate (OP-1, blocking):** a running **`anvil`** instance must be available for the
+  Engineer to verify `yarn forge:test`. Without it the suite cannot execute against the
+  diamond. Owner confirms availability (local and CI).
+- **Downstream:** M1-E1/E3 deepen these Foundry assertions further (full event matching,
+  guard-reason coverage); M3 is the final gate.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Negative tests re-pass for the wrong reason after migration | Assert the *specific* revert string/selector, not `success == false` |
+| `anvil` not running → suite skipped/misreported as pass | OP-1 gate; document the prerequisite; wire into CI (M3) |
+| `_boundUint256` / balance setup interacts badly with the real burn path | Verify against actual balances; mint as needed before bridging |
+| Removing the length test loses a real coverage intent | Confirm intent is obsolete — `bytes32` cannot vary in length; superseded by destination-key edge cases in M1-E2 |
+
+## Notes
+
+- Reversible: test-only (`BridgeFuzz.t.sol` + Foundry base constants).
+- Three `bridgeOut` forms exist across the tree (see design doc
+  [§5 signature evolution](../../../bridge-test-realignment-architecture.md)); this epic
+  retires the interim `bytes` form from Foundry, matching what M0-E1 does for the original
+  3-arg form in Hardhat.

--- a/project/bridge-test-realignment/Milestone-00/Epic-04/prd-e4-fix-foundry-fuzz-bridgeout.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-04/prd-e4-fix-foundry-fuzz-bridgeout.md
@@ -1,0 +1,116 @@
+# PRD — Fix Foundry Fuzz bridgeOut (M0-E4)
+
+> **Epic:** [e4-fix-foundry-fuzz-bridgeout](./overview/e4-fix-foundry-fuzz-bridgeout.md) ·
+> **Milestone:** [M0 — Green Baseline](../overview/milestone-01-green-baseline.md) ·
+> **Plan:** [project-plan §5 M0-E4](../../bridge-test-realignment-project-plan.md)
+> **Status:** 📋 ready for `/generate-tasks` · **Author:** Am0rfu5 · **Date:** 2026-06-19
+
+## 1. Introduction / Overview
+
+The Foundry bridge fuzz suite, [BridgeFuzz.t.sol](../../../../../test/foundry/fuzz/BridgeFuzz.t.sol),
+calls `bridgeOut` using the **interim `bytes`-based** signature
+`bridgeOut(uint256,uint256,uint256,bytes)` (selector `0xf7587f7d`). That selector **no
+longer exists** on the diamond — the current function is
+`bridgeOut(uint256,uint256,uint256,bytes32,bool)`. Every low-level `diamond.call(...)`
+therefore reverts, regardless of input. The consequences:
+
+- `testFuzz_bridgeAmountEdgeCases` **fails** — it asserts `success == true`, but the call
+  always reverts (failed on run 0).
+- `testFuzz_RevertWhen_depositExceedsBalance` and `test_RevertWhen_InvalidDestinationKeyLength`
+  are **false-greens** — they assert `success == false` and "pass," but only because the
+  selector is missing, not because the contract logic rejected anything.
+- `testFuzz_bridgeDeposit` has **no assertion** — it passes silently no matter what.
+
+This feature migrates the suite to the current signature and makes every test assert a real,
+intended outcome. It is a test-only change.
+
+## 2. Goals
+
+- **G1** — Every `bridgeOut` call uses `bridgeOut(uint256,uint256,uint256,bytes32,bool)`.
+- **G2** — `testFuzz_bridgeAmountEdgeCases` passes against a **real** (existing) bridge call.
+- **G3** — Negative tests assert the **specific** intended revert reason, not bare failure.
+- **G4** — The happy-path test asserts observable effects (balance burned **and**
+  `BridgeOutInitiated` emitted), not a silent no-op.
+- **G5** — The obsolete `test_RevertWhen_InvalidDestinationKeyLength` is removed.
+- **G6** — `yarn clean-compile && yarn forge:test` (with `anvil` running) reports 0 failing.
+
+## 3. User Stories
+
+- **As a developer,** I want the fuzz suite to call the real bridge, so a passing run
+  actually means the bridge accepted/rejected the input — not that a selector was missing.
+- **As a reviewer,** I want negative tests to assert *why* a call failed, so a future
+  signature change can't turn them back into false-greens.
+
+## 4. Functional Requirements
+
+**Signature & fixtures**
+
+1. The system must replace every `abi.encodeWithSignature("bridgeOut(uint256,uint256,uint256,bytes)", ...)`
+   in `BridgeFuzz.t.sol` with the current 5-parameter form
+   `bridgeOut(uint256 amount, uint256 id, uint256 destChainID, bytes32 sgnsDestination, bool destinationYOdd)`.
+2. Destination arguments must come from the Foundry base constants added in M0-E3
+   (`bytes32 SGNS_DESTINATION` + `bool SGNS_DESTINATION_Y_ODD`), replacing the 64-byte
+   `bytes TEST_SGNS_DEST`.
+
+**Assertion approach**
+
+3. `bridgeOut` calls intended to succeed or to revert for a checkable reason must be made
+   through a **typed interface** (not a raw `diamond.call`), so failures can be asserted
+   precisely.
+4. `testFuzz_RevertWhen_depositExceedsBalance` must use `vm.expectRevert` with the specific
+   reason for an over-balance bridge (`"Insufficient tokens."`) rather than asserting a bare
+   boolean.
+5. `testFuzz_bridgeAmountEdgeCases` must call the real bridge for a valid bounded amount and
+   pass because the bridge **accepted** it (mint sufficient balance first if needed).
+6. `testFuzz_bridgeDeposit` must assert observable effects: the sender's token balance
+   decreased by the bridged `amount` **and** a `BridgeOutInitiated` event was emitted (use
+   `vm.expectEmit`; full 7-field arg matching is deferred to M1-E1).
+
+**Cleanup**
+
+7. The system must delete `test_RevertWhen_InvalidDestinationKeyLength` — a `bytes32`
+   destination is fixed-length, so "wrong length" is unreachable.
+8. After migration, `TEST_SGNS_DEST` must be unreferenced in `test/foundry`; its removal
+   from the base is coordinated with M0-E3/M0-E4 (whichever lands last removes it).
+
+**Verification**
+
+9. `yarn clean-compile && yarn forge:test`, run against a live `anvil`, must report 0
+   failing and the previously-failing fuzz test must pass for the right reason.
+
+## 5. Non-Goals (Out of Scope)
+
+- Full 7-field `BridgeOutInitiated` argument matching and broader guard coverage (M1).
+- Standing up `anvil` itself — that is an environment prerequisite (owner gate OP-1), not a
+  code task.
+- Any production contract change.
+- Adding new fuzz dimensions beyond repairing the existing tests.
+
+## 6. Technical Considerations
+
+- **Dependency:** M0-E3 must add the Foundry `bytes32`/`bool` constants first.
+- **Owner gate (OP-1, blocking):** a running `anvil` instance is required to verify
+  `yarn forge:test`; without it the suite cannot execute against the diamond.
+- **Typed interface:** define or reuse an interface exposing
+  `bridgeOut(uint256,uint256,uint256,bytes32,bool)` so `vm.expectRevert`/`vm.expectEmit`
+  attach to a typed call; the base (`GeniusDiamondTestBase`) already provides `diamond`,
+  `_mintGNUS`, `_getGNUSBalance`, and `GNUS_TOKEN_ID`.
+- **Balance setup:** edge-case and happy-path tests must ensure the sender holds enough
+  tokens before bridging (mint via `_mintGNUS`).
+- **Same-chain guard:** use a `destChainID` `!=` the local anvil chain id (the M0-E3
+  canonical value).
+
+## 7. Success Metrics
+
+- Foundry suite: 0 failing; the prior 1 failing fuzz test now green for the right reason.
+- The two former false-greens now fail if the *intended* revert reason changes (verified by
+  the specificity of `vm.expectRevert`).
+- `testFuzz_bridgeDeposit` fails if the balance isn't burned or the event isn't emitted
+  (no silent-pass path remains).
+- No `encodeWithSignature("bridgeOut(...,bytes)")` and no `TEST_SGNS_DEST` reference remain.
+
+## 8. Open Questions
+
+- Where to declare the typed `bridgeOut` interface — a shared test interface file vs inline
+  in the base? *Default: add it to the Foundry base/test interfaces alongside existing
+  helpers.* Resolve during `/generate-tasks`.

--- a/project/bridge-test-realignment/Milestone-00/Epic-04/tasks-e4-fix-foundry-fuzz-bridgeout.md
+++ b/project/bridge-test-realignment/Milestone-00/Epic-04/tasks-e4-fix-foundry-fuzz-bridgeout.md
@@ -1,0 +1,60 @@
+# Tasks — Fix Foundry Fuzz bridgeOut (M0-E4)
+
+> **PRD:** [prd-e4-fix-foundry-fuzz-bridgeout](./prd-e4-fix-foundry-fuzz-bridgeout.md) ·
+> **Epic:** [e4-fix-foundry-fuzz-bridgeout](./overview/e4-fix-foundry-fuzz-bridgeout.md) ·
+> **Milestone:** [M0 — Green Baseline](../overview/milestone-01-green-baseline.md)
+
+## Relevant Files & Resources
+
+- `test/foundry/fuzz/BridgeFuzz.t.sol` - **Modified.** Migrated to `IGNUSBridgeOut.bridgeOut(...,bytes32,bool)`; real assertions (balance burned, expectEmit, expectRevert); obsolete length test removed.
+- `test/foundry/handlers/GeniusDiamondHandler.sol` - **Modified.** `handler_bridgeDeposit` uses the typed `try/catch` bridgeOut; dest chain `1` → `DEST_CHAIN_ID`.
+- `test/foundry/base/GeniusDiamondTestBase.sol` - **Modified.** Added `IGNUSBridgeOut` interface + `DEST_CHAIN_ID`; removed deprecated `TEST_SGNS_DEST`.
+- `test/utils/bridge-fixtures.ts` - TS counterpart of the constants (reference only; not edited).
+- `…/Epic-04/CHANGELOG.md` - **Created.** Epic change log.
+- Local `anvil` instance (chain 31337) - required to run `yarn forge:test` (owner gate OP-1).
+
+### Notes
+
+- Prefer asserting the *specific* revert reason (`vm.expectRevert`) over bare `success == false`, so the tests can't regress into false-greens again.
+- `yarn forge:test` needs a running `anvil` AND a fresh `yarn clean-compile` first (else HH701 "multiple artifacts for GeniusDiamond").
+- Baseline to beat: Foundry **216 passed / 1 failed / 1 skipped**; this epic should make it **0 failed**. Hardhat (371/2/0) must stay unregressed.
+- `TEST_SGNS_DEST` may only be deleted after BOTH `BridgeFuzz.t.sol` and `GeniusDiamondHandler.sol` no longer reference it.
+
+## Tasks
+
+- [x] 0.0 Prepare & safeguard
+  - [x] 0.1 Created and checked out `chore/fix-foundry-fuzz-bridgeout` off `chore/fix-gas-test-bridgeout`
+  - [x] 0.2 Confirmed local `anvil` on :8545 (chain 31337) — owner gate OP-1
+  - [x] 0.3 Foundry baseline recorded: **216 passed / 1 failed / 1 skipped** (failure: `BridgeFuzz::testFuzz_bridgeAmountEdgeCases`)
+
+- [x] 1.0 Add a typed `bridgeOut` interface + canonical dest-chain id to the Foundry test base
+  - [x] 1.1 Added `interface IGNUSBridgeOut` (bytes32+bool signature) at file scope in `GeniusDiamondTestBase.sol`
+  - [x] 1.2 Added `uint256 public constant DEST_CHAIN_ID = 137;` to the base, paired with the TS fixture
+  - [x] 1.3 Confirmed by analysis: the diamond's `chainID` defaults to **0** (no init sets it; `setChainID` is `onlySuperAdminRole`), so `DEST_CHAIN_ID = 137 != 0` passes the same-chain guard — no `setChainID` needed
+  - [x] 1.4 Compile verified in 4.1 (batched to avoid repeated 2-min builds)
+
+- [x] 2.0 Migrate `BridgeFuzz.t.sol` to the new signature with meaningful assertions (and remove the obsolete length test)
+  - [x] 2.1 All bridge calls now `IGNUSBridgeOut(diamond).bridgeOut(amount, GNUS_TOKEN_ID, DEST_CHAIN_ID, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD)`
+  - [x] 2.2 `testFuzz_bridgeAmountEdgeCases`: mints enough balance, bounds amount, expects success — passes against a real bridge (verified GNUS id 0 is created at init via `GNUSNFTFactory_Initialize`)
+  - [x] 2.3 `testFuzz_RevertWhen_depositExceedsBalance`: `vm.expectRevert("Insufficient tokens.")` before the typed call
+  - [x] 2.4 `testFuzz_bridgeDeposit`: asserts balance decreased by `amount`; `vm.expectEmit` (indexed sender) for `BridgeOutInitiated` (event mirrored in the test; full arg matching deferred to M1-E1)
+  - [x] 2.5 Deleted `test_RevertWhen_InvalidDestinationKeyLength` (bytes32 is fixed-length)
+  - [x] 2.6 Removed the `abi.encodeWithSignature`/`callData` locals
+
+- [x] 3.0 Migrate the invariant handler `GeniusDiamondHandler.sol`, then remove the now-unreferenced `TEST_SGNS_DEST`
+  - [x] 3.1 `handler_bridgeDeposit` now uses `try IGNUSBridgeOut(diamond).bridgeOut(...) { ghost++; calls++; } catch {}` (success-gated ghost counters preserved)
+  - [x] 3.2 Destination chain `1` → `DEST_CHAIN_ID`; `vm.prank(currentActor)` kept
+  - [x] 3.3 Grep confirmed no other `TEST_SGNS_DEST` consumers; deleted the deprecated `bytes` constant from the base
+  - [x] 3.4 Compile verified in 4.1
+
+- [x] 4.0 Validate the change (clean-compile + `forge:test` green; no Hardhat regression)
+  - [x] 4.1 `yarn clean-compile && yarn forge:test` (anvil) → **216 passed / 0 failed / 1 skipped** (exit 0); `BridgeFuzz` 3/3 green
+  - [x] 4.2 Zero `0xf7587f7d` missing-selector calldata in the log — edge case passes for the right reason
+  - [x] 4.3 Negative test asserts the specific reason `"Insufficient tokens."` (fails if the reason changes)
+  - [x] 4.4 Only `test/foundry/**` changed; no production contract/`scripts` change → Hardhat unaffected (stays 371/2/0)
+  - [x] 4.5 Final vs baseline: 218→217 total (−1 obsolete test), 1 failed → **0 failed**
+
+- [x] 5.0 Record the change (CHANGELOG + task file) and commit
+  - [x] 5.1 Appended summary to `…/Epic-04/CHANGELOG.md`
+  - [x] 5.2 Updated this file's results + Relevant Files
+  - [x] 5.3 Staged only E4 files (excluded the owner-gated submodule and the unrelated E2 edit); committed on `chore/fix-foundry-fuzz-bridgeout`

--- a/project/bridge-test-realignment/Milestone-00/overview/milestone-01-green-baseline.md
+++ b/project/bridge-test-realignment/Milestone-00/overview/milestone-01-green-baseline.md
@@ -1,0 +1,136 @@
+# Milestone 1 — Green Baseline (M0)
+
+> **Maps to:** [`bridge-test-realignment-project-plan.md` → §5 M0](../../bridge-test-realignment-project-plan.md) · design: [`bridge-test-realignment-architecture.md` §1, §5](../../bridge-test-realignment-architecture.md)
+> **Status:** 📋 planned — ready for `/breakout-epics`
+> **Prod/impact:** None at runtime (test-only). High developer impact — unblocks a trustworthy CI signal.
+> **Author:** Am0rfu5 · **Date:** 2026-06-19
+>
+> **Epic breakouts** (resolve after `/breakout-epics`):
+> [E1 fix-gas-test-bridgeout](../Epic-01/overview/e1-fix-gas-test-bridgeout.md) ·
+> [E2 retire-openescrow-test](../Epic-02/overview/e2-retire-openescrow-test.md) ·
+> [E3 shared-bridge-fixtures](../Epic-03/overview/e3-shared-bridge-fixtures.md) ·
+> [E4 fix-foundry-fuzz-bridgeout](../Epic-04/overview/e4-fix-foundry-fuzz-bridgeout.md)
+
+---
+
+## 1. Why this milestone exists
+
+The contracts on `feature/bridge-out-initiated` are refactored and correct, but **both**
+test runners are red against them:
+
+- **Hardhat:** 6 failures — 5 from the gas test calling the old 3-arg `bridgeOut`, 1 from
+  a removed `OpenEscrow` reference (already commented out in the working tree).
+- **Foundry:** 1 failure + hidden false-greens — `BridgeFuzz.t.sol` targets the *interim*
+  `bridgeOut(...,bytes)` selector that no longer exists on the diamond, so calls silently
+  revert.
+
+A red suite means no trustworthy regression signal for any later work. M0 is the **root of
+the critical path**: every other milestone (conformance, removal coverage, the zero-debt
+gate) builds on a green, fixture-centralized baseline. The milestone also fixes the *cause*
+of the drift — per-file constant duplication — not just the symptoms, so the same failure
+class can't silently recur.
+
+## 2. Goal & exit criteria
+
+**Goal:** Eliminate the 6 Hardhat failures and the 1 Foundry fuzz failure, repair the
+Foundry false-greens, and centralize bridge test constants so a future signature change is
+a one-file edit per runner — leaving both runners green.
+
+**Exit criteria:**
+
+- [ ] `npx hardhat test` reports **0 failing** (was 6).
+- [ ] `yarn clean-compile && yarn forge:test` (against a running **`anvil`**) reports **0 failing** (was 1).
+- [ ] The gas test ([withdraw-limiter-gas-comparison.test.ts:205](../../../../test/gas/withdraw-limiter-gas-comparison.test.ts#L205)) calls the 5-arg `bridgeOut(amount, id, destChainID, sgnsDestination, destinationYOdd)`.
+- [ ] The commented-out `OpenEscrow` ownership test is **resolved** (rewritten escrow-free or deleted with a written reason) — no commented test left behind.
+- [ ] `BridgeFuzz.t.sol` uses the `bridgeOut(uint256,uint256,uint256,bytes32,bool)` selector; `testFuzz_bridgeAmountEdgeCases` passes for the right reason.
+- [ ] The two Foundry **false-green** negative tests assert the *intended* revert reason, not bare `success == false`.
+- [ ] The obsolete `test_RevertWhen_InvalidDestinationKeyLength` is removed (a `bytes32` cannot be the wrong length).
+- [ ] Bridge constants (`SGNS_DESTINATION`, `SGNS_DESTINATION_Y_ODD`, canonical `destChainID`, `GNUS_TOKEN_ID`) come from **one shared module per runner**; duplicate per-file definitions removed.
+- [ ] Suite-health counts recorded at milestone close (Hardhat + Foundry).
+
+## 3. Scope
+
+**In scope**
+- Updating Hardhat gas-test `bridgeOut` call sites to the 5-arg form.
+- Resolving the commented-out `OpenEscrow` ownership test.
+- Migrating `BridgeFuzz.t.sol` + the Foundry test base to the `bytes32,bool` destination.
+- Repairing Foundry false-green negative tests and removing the obsolete length test.
+- Extracting shared bridge-fixture modules (one for Hardhat TS, one for the Foundry base).
+
+**Out of scope (deferred)**
+- Deepened conformance assertions (full 7-field `BridgeOutInitiated` matching, destination-key
+  edge cases, guard-reason coverage) → **M1**.
+- `OpenEscrow`-selector-absent negative test and DiamondInitFacet facet-set coverage → **M2**.
+- Resolving the 2 pending/skipped tests (rpc-deployment, test-template) → **M3**.
+- Any contract change. If a failure traces to a contract defect, **stop and escalate** (see Roles).
+
+## 4. Roles on this milestone
+
+| Role | Responsibility |
+|---|---|
+| **Engineer** (agent-executable) | All test-file and fixture edits in E1–E4; run both suites locally; record counts. |
+| **Owner (Am0rfu5)** | **Blocking:** confirm a local **`anvil`** instance is available for `yarn forge:test`; decide keep-vs-delete if any test cannot be made meaningful escrow-free; approve any escalation. No submodule-pointer or merge action is required *within* M0. |
+
+Contract-bug escalation is a **blocking owner gate**: if a test only goes green by weakening
+an assertion against intended contract behavior, the Engineer stops and the Owner rules on it.
+
+## 5. Epics
+
+| Epic | Title | Owner | Impact | Breakout |
+|---|---|---|---|---|
+| M0-E1 | fix-gas-test-bridgeout | Engineer | High | [e1](../Epic-01/overview/e1-fix-gas-test-bridgeout.md) |
+| M0-E2 | retire-openescrow-test | Engineer | High | [e2](../Epic-02/overview/e2-retire-openescrow-test.md) |
+| M0-E3 | shared-bridge-fixtures | Engineer | High | [e3](../Epic-03/overview/e3-shared-bridge-fixtures.md) |
+| M0-E4 | fix-foundry-fuzz-bridgeout | Engineer | High | [e4](../Epic-04/overview/e4-fix-foundry-fuzz-bridgeout.md) |
+
+### M0-E1 — fix-gas-test-bridgeout
+The 5 failing bin-count cases in [withdraw-limiter-gas-comparison.test.ts:205](../../../../test/gas/withdraw-limiter-gas-comparison.test.ts#L205) call `bridgeOut(gnusAmount, GNUS_TOKEN_ID, 137)` — the old 3-arg form — so ethers can't resolve a fragment. **Acceptance:** all 5 cases construct gas with the 5-arg call (destination + Y-parity sourced from the shared fixture once E3 lands), and the gas-comparison still records a value. **Risk:** low; the sibling `GNUSBridgeEnhanced.test.ts` already demonstrates the exact call shape. **Key tasks:** update the call; pull `SGNS_DESTINATION`/`SGNS_DESTINATION_Y_ODD` from the shared module; re-run the gas suite.
+
+### M0-E2 — retire-openescrow-test
+The `GeniusOwnershipFacet` "maintain contract state across ownership transfer" test referenced the removed `OpenEscrow`; it is currently **commented out** ([GeniusOwnershipFacet.test.ts:259-276](../../../../test/unit/GeniusOwnershipFacet.test.ts#L259-L276)). A commented test is undocumented debt. **Acceptance:** the intent (state survives an ownership transfer) is either re-expressed **without** escrow — e.g. mint a balance, transfer ownership, assert balance/roles unchanged — or the test is deleted with a one-line reason. No commented-out block remains. **Risk:** low. **Key tasks:** decide rewrite-vs-delete; implement; ensure no `OpenEscrow` text survives even in comments.
+
+### M0-E3 — shared-bridge-fixtures
+Root-cause fix. Constants are redefined per file, which is exactly why `GNUSBridgeEnhanced.test.ts` was updated but the gas test and Foundry suite drifted. **Acceptance:** one Hardhat/TS fixture module exports `SGNS_DESTINATION`, `SGNS_DESTINATION_Y_ODD`, canonical `destChainID`, `GNUS_TOKEN_ID`; the Foundry `GeniusDiamondTestBase.sol` exposes the matching `bytes32` X + `bool` Y-parity (replacing the 64-byte `bytes TEST_SGNS_DEST`). All bridge specs import from these; no duplicate literals remain. **Risk:** low–medium (touches multiple files; must keep values identical to current passing tests). **Key tasks:** create the modules; refactor E1/E4 call sites to import; grep for stray literals. **Sequencing:** logically lands with/just before E1 and E4 so they consume it.
+
+### M0-E4 — fix-foundry-fuzz-bridgeout
+[BridgeFuzz.t.sol](../../../../test/foundry/fuzz/BridgeFuzz.t.sol) uses the interim `bridgeOut(uint256,uint256,uint256,bytes)` selector (`0xf7587f7d`), absent from the diamond — so every call reverts. This both **fails** `testFuzz_bridgeAmountEdgeCases` (`assertTrue(success)` on run 0) and **false-greens** `testFuzz_RevertWhen_depositExceedsBalance` and `test_RevertWhen_InvalidDestinationKeyLength` (they pass only because the selector is missing). **Acceptance:** all calls use `bridgeOut(uint256,uint256,uint256,bytes32,bool)` via the E3 Foundry fixture; the edge-case test passes against a real bridge; the balance-exceeded test asserts the *specific* revert; the obsolete length test is removed (`bytes32` is fixed-length). **Risk:** medium — requires a running `anvil` and correct fixture migration. **Key tasks:** migrate selectors + fixtures; rewrite negative tests to check the real revert reason; delete obsolete test; run `yarn clean-compile && yarn forge:test`.
+
+## 6. Dependencies & sequencing
+
+- **Upstream:** none — M0 is the first milestone and the project's critical-path root.
+- **Internal ordering:** **E3 first (or alongside)** so E1 and E4 import the shared
+  fixtures rather than re-introducing literals. E2 is independent and can run in parallel.
+  E1 (Hardhat) and E4 (Foundry) are independent of each other once E3 exists.
+- **Owner gate (blocking):** a usable **`anvil`** instance must be confirmed before E4 can
+  be verified.
+- **Downstream:** M1 (conformance) and M2 (removal/submodule) both depend on this green,
+  fixture-centralized baseline; M3 is the final gate.
+
+## 7. Rollback posture
+
+Test-only and fully revertible via git. Reverting M0's commits returns the suites to the
+known baseline (Hardhat 6 failing; Foundry 1 failing + 1 skipped). No system, deployment,
+or submodule-pointer state is touched in this milestone.
+
+## 8. Risks (milestone-scoped)
+
+| Risk | Mitigation |
+|---|---|
+| A failure actually signals a contract bug | Escalate to Owner; never weaken an assertion to pass (blocking gate). |
+| Shared-fixture extraction changes a value and breaks a currently-passing test | Copy values verbatim from existing passing specs; diff before/after pass counts. |
+| Foundry suite can't run / misreports because `anvil` isn't up | Confirm `anvil` + `yarn clean-compile` prerequisite before E4 verification. |
+| False-greens "fixed" into still-meaningless tests | Require negative tests to assert the *specific* revert reason, not bare `success == false`. |
+| Residual `OpenEscrow`/old-selector literals left in comments or other files | grep sweep as an exit check across `test/`. |
+
+## 9. Definition of Done for Milestone 1 (M0)
+
+M0 is closeable when **all** §2 exit-criteria boxes are checked: both runners green, all
+seven originally-failing assertions fixed or properly retired, false-greens repaired,
+obsolete length test removed, constants centralized per runner, and suite-health counts
+recorded at the boundary — with no contract changes and no undocumented commented/skipped
+tests introduced.
+
+---
+
+**▶ Next:** run `/breakout-epics` to expand M0's four epics (E1–E4) into their own
+`Epic-MM/` directories with epic-overview docs ready for `/create-prd`.

--- a/project/bridge-test-realignment/bridge-test-realignment-architecture.md
+++ b/project/bridge-test-realignment/bridge-test-realignment-architecture.md
@@ -1,0 +1,149 @@
+# Bridge Test Realignment — Companion Design Doc
+
+> **Status:** 🧭 design of record (read this before the project plan)
+> **Author:** Am0rfu5 · **Date:** 2026-06-19
+> **Scope:** Captures the *already-decided* contract design that the test suite must
+> conform to. This is descriptive (the target the tests verify), not a proposal.
+
+This document records the contract-level design decisions introduced on
+`feature/bridge-out-initiated` so the test suite can be realigned against a single
+source of truth. The implementation is done; the tests are catching up.
+
+---
+
+## 1. `bridgeOut` signature change
+
+The cross-chain bridge-out entrypoint expanded from a 3-argument call (which carried
+only routing) to a 5-argument call that carries the **destination recipient identity**
+on the SuperGenius (SGNS) chain.
+
+| | Old (main) | New (`feature/bridge-out-initiated`) |
+|---|---|---|
+| Signature | `bridgeOut(uint256 amount, uint256 id, uint256 destChainID)` | `bridgeOut(uint256 amount, uint256 id, uint256 destChainID, bytes32 sgnsDestination, bool destinationYOdd)` |
+| Event | (prior name) | `BridgeOutInitiated(address indexed sender, uint256 id, uint256 amount, uint256 srcChainID, uint256 destChainID, bytes32 sgnsDestination, bool destinationYOdd)` |
+
+Reference: [GNUSBridge.sol:187-209](../../contracts/gnus-ai/GNUSBridge.sol#L187-L209).
+
+### Behavioral contract (what tests must assert)
+
+- **Burn-then-emit:** `bridgeOut` burns `amount` of token `id` from the sender, then
+  emits `BridgeOutInitiated`. There is no mint on the source chain — value is
+  reconstructed on the destination chain by an off-chain relayer reading the event.
+- **Guards:**
+  - `NFTs[id].nftCreated` must be true → `"Token not created."`
+  - `balanceOf(sender, id) >= amount` → `"Insufficient tokens."`
+  - `destChainID != layout().chainID` → `"Cannot bridge to same chain"`
+- **Event field provenance:** `srcChainID` is read from `GNUSControlStorage.layout().chainID`
+  (it is **not** a caller argument); `sender` is `_msgSender()`; the remaining fields echo
+  the call arguments.
+
+---
+
+## 2. Destination key: `bytes32 sgnsDestination` + `bool destinationYOdd`
+
+The destination recipient on the SGNS chain is **not** an Ethereum address. It is an
+elliptic-curve public key. To carry it compactly the design uses **compressed-point
+encoding**:
+
+- `sgnsDestination` — the 32-byte **X coordinate** of the recipient's public key.
+- `destinationYOdd` — the **parity of the Y coordinate** (`false` = even, `true` = odd).
+
+Together these reconstruct the full public key on the destination side (standard
+compressed-point reconstruction). Test fixtures model this as:
+
+```ts
+const SGNS_DESTINATION = ethers.zeroPadValue('0x1234', 32); // 32-byte X component
+const SGNS_DESTINATION_Y_ODD = false;                       // Y parity (even)
+```
+
+Reference: [GNUSBridgeEnhanced.test.ts:21-23](../../test/unit/GNUSBridgeEnhanced.test.ts#L21-L23).
+
+### Test obligations for the destination key
+
+- Event assertions must match **all seven** event fields, including `sgnsDestination`
+  and `destinationYOdd` (current passing tests in `GNUSBridgeEnhanced.test.ts` already do;
+  the gas test and any new tests must follow).
+- Edge cases worth covering: zero-X value, max `bytes32` X, both parity values.
+- The destination key is opaque to the source contract — there is **no on-chain
+  validation** of curve membership, so tests should assert the contract faithfully
+  forwards whatever it is given rather than expecting rejection.
+
+---
+
+## 3. Removal of GeniusAI / `OpenEscrow`
+
+The `GeniusAI` contract — which provided the `OpenEscrow` payable function — was removed
+from the diamond. This is a **submodule** change in `diamonds/GeniusDiamond`
+(commit `5d26a14 feat: remove GeniusAI contract from config`), surfaced in the
+superproject as the modified `diamonds/GeniusDiamond` pointer.
+
+### Implications for the suite
+
+- No `OpenEscrow` selector should remain wired into the diamond. Any test that called it
+  (e.g. `GeniusOwnershipFacet` "maintain contract state across ownership transfer") must
+  be rewritten to exercise state persistence **without** escrow, or removed.
+- A conformance test should assert the `OpenEscrow` selector is **absent** from the
+  diamond's facets (negative coverage), so accidental re-introduction is caught.
+
+---
+
+## 4. DiamondInitFacet changes (submodule)
+
+`DiamondInitFacet.sol` was modified in the `diamonds/GeniusDiamond` submodule as part of
+the same cleanup (GeniusAI removed from init wiring; `GNUSWithdrawLimiter` added to the
+diamond configuration — submodule commits `5d26a14` and `6800205`). The superproject's
+`contracts/gnus-ai/DiamondInitFacet.sol` shows no diff vs `main`; the change of record is
+in the submodule.
+
+### Test obligations
+
+- Diamond initialization tests must reflect the **current** facet set: WithdrawLimiter
+  present, GeniusAI/OpenEscrow absent.
+- Init wiring (roles, storage defaults such as `chainID`, `bridgeFee`) must be asserted
+  against the new config so a stale submodule pointer is caught by a failing test rather
+  than silently drifting.
+
+---
+
+## 5. Source-of-truth & fixtures
+
+To prevent the exact drift this project is fixing, the design calls for **one shared
+fixture module per runner** for bridge test constants (`SGNS_DESTINATION`,
+`SGNS_DESTINATION_Y_ODD`, `GNUS_TOKEN_ID`, canonical `destChainID`) imported by every
+bridge-touching spec. Today they are redefined per-file, which is why
+`GNUSBridgeEnhanced.test.ts` was updated but the Hardhat gas test was not.
+
+### Signature evolution (three forms seen in the tree)
+
+The destination parameter went through **two** revisions, and the test tree still
+contains all three forms — this is the source of the drift:
+
+1. `bridgeOut(uint256,uint256,uint256)` — original, no destination. (Hardhat gas test.)
+2. `bridgeOut(uint256,uint256,uint256,bytes)` — interim `bytes`-encoded destination key.
+   Still used by the **Foundry** suite (`BridgeFuzz.t.sol` + the 64-byte `bytes
+   TEST_SGNS_DEST` in `GeniusDiamondTestBase.sol`). This selector no longer exists on the
+   diamond, so every Foundry `bridgeOut` call silently reverts — failing one test and
+   producing **false-greens** in the negative tests.
+3. `bridgeOut(uint256,uint256,uint256,bytes32,bool)` — **current** (X + Y-parity). Only
+   `GNUSBridgeEnhanced.test.ts` is aligned to it.
+
+Because the current form is a fixed-length `bytes32`, the interim "invalid destination key
+length" test is **obsolete** and should be removed — a `bytes32` cannot have a wrong length.
+
+### Foundry environment prerequisite
+
+`yarn forge:test` must be preceded by `yarn clean-compile` and requires a running
+**`anvil`** instance. Without it the Foundry suite cannot execute against the diamond, so
+this is a prerequisite for every Foundry-touching change and for the final green gate.
+
+---
+
+## 6. Decision log
+
+| Decision | Rationale |
+|---|---|
+| Carry destination as compressed pubkey (X + Y-parity), not address | SGNS recipients are EC keys, not EVM addresses; compressed form fits `bytes32 + bool` and is relayer-reconstructable. |
+| `srcChainID` read from storage, not passed in | Prevents caller spoofing of source chain in the emitted event. |
+| Remove GeniusAI/`OpenEscrow` from diamond | Escrow feature retired; removing the facet shrinks attack surface and selector table. |
+| Add negative test for absent `OpenEscrow` selector | Guards against accidental facet re-introduction. |
+| Centralize bridge test fixtures | Root-causes the per-file constant drift that caused these failures. |

--- a/project/bridge-test-realignment/bridge-test-realignment-project-plan.md
+++ b/project/bridge-test-realignment/bridge-test-realignment-project-plan.md
@@ -1,0 +1,245 @@
+# Bridge Test Realignment — Project Plan
+
+> **Status:** 📋 Plan of record — for owner approval
+> **Author:** Am0rfu5 · **Date:** 2026-06-19
+> **Companion design doc:** [bridge-test-realignment-architecture.md](./bridge-test-realignment-architecture.md) — **read this first**; it is the source of truth for the contract behavior the tests must verify.
+>
+> **Governing constraint:** The contracts are already refactored and are the source of
+> truth. This project changes **tests only** — it must not alter contract behavior. "Done"
+> means **both** test runners green — Hardhat (`npx hardhat test`) **and** Foundry
+> (`yarn forge:test`) — with assertions that reflect the new bridge design, **zero**
+> pending or commented-out tests left undocumented, and **zero false-greens** (tests that
+> pass for the wrong reason, e.g. because a stale selector simply doesn't exist).
+
+---
+
+## 1. How to read this plan
+
+Work is decomposed into **milestones** (independently-valuable, releasable steps that each
+leave the suite in a working state) and **epics** (coherent units of work tracked
+together). Stable IDs used across the whole pipeline:
+
+- **Milestones:** `M0`…`M3` (zero-indexed; `M0` is the green-baseline foundation).
+- **Epics:** `M<n>-E<m>` (e.g. `M1-E2`).
+- **Slugs:** short kebab-case.
+
+**Roles referenced:**
+- **Engineer** — writes/edits test code (the bulk of this work; agent-executable).
+- **Owner (Am0rfu5)** — approves the plan, owns the `diamonds/GeniusDiamond` **submodule
+  pointer commit**, and any merge/push to `feature/bridge-out-initiated` or `main`.
+  Submodule-pointer and merge decisions are **blocking owner tasks** (see §7).
+
+---
+
+## 2. Objectives & success criteria
+
+| # | Objective | Measurable definition of done |
+|---|---|---|
+| O1 | Green test suites | `npx hardhat test` **and** `yarn forge:test` (with a running `anvil`) both report **0 failing**; the 6 Hardhat failures and the 1 Foundry fuzz failure are gone. |
+| O1b | No false-greens | No test passes because a stale/missing selector reverts; negative tests assert the *intended* revert reason. |
+| O2 | Tests reflect new bridge design | Every `bridgeOut` call site uses the 5-arg form; `BridgeOutInitiated` is asserted with all 7 fields including `sgnsDestination` + `destinationYOdd`. |
+| O3 | Removal coverage | No test references `OpenEscrow`/`GeniusAI`; a negative test asserts the `OpenEscrow` selector is absent from the diamond. |
+| O4 | Submodule conformance | Diamond-init tests assert the current facet set (WithdrawLimiter present, GeniusAI absent); stale submodule pointer fails a test rather than passing silently. |
+| O5 | No undocumented debt | **0** pending/`skip`/`xit`/commented tests remain without a tracked, written decision; ideally **0** pending tests. |
+| O6 | Drift prevention | Bridge test constants live in **one** shared fixture imported by all bridge specs. |
+
+**Overarching acceptance gate:** `npx hardhat test` green (0 failing) **and** O2–O6
+verified by review, on `feature/bridge-out-initiated`.
+
+---
+
+## 3. Guiding execution principles
+
+- **Tests follow contracts, never the reverse.** If a test failure reveals a *contract*
+  bug, stop and escalate to the Owner — do not "fix" by weakening the test.
+- **One behavior per test; assert the full event.** Prefer complete `withArgs` matching
+  over partial/`emit`-only checks for `BridgeOutInitiated`.
+- **Root-cause, don't patch.** The failures stem from per-file constant drift — fix the
+  cause (shared fixtures) not just the symptom.
+- **Green at every milestone boundary.** Each milestone ends with the suite at least as
+  green as it started; no milestone leaves it broken.
+- **No silent skips.** Any test that stays skipped exits with a `// reason:` comment and a
+  tracked decision.
+- **Owner-gate irreversible/outward actions.** Submodule-pointer commits, branch
+  merges, and pushes are Owner-only.
+
+---
+
+## 4. Milestone map (at a glance)
+
+| Milestone | Title | Outcome | Impact / Risk | Realizes design § |
+|---|---|---|---|---|
+| **M0** | Green baseline | 6 Hardhat + 1 Foundry failures fixed; Foundry false-greens repaired; shared fixtures established | High value / Low risk | §1, §5 |
+| **M1** | Bridge-design conformance | Suite asserts new signature, event, destination-key semantics | High value / Low risk | §1, §2 |
+| **M2** | Removal & submodule coverage | GeniusAI/OpenEscrow removal + DiamondInit facet set covered | Medium value / Medium risk (submodule) | §3, §4 |
+| **M3** | Zero-debt green gate | Pending tests resolved; final full-suite gate + CI | Medium value / Low risk | all |
+
+**Critical path:** `M0 → M1 → M3`. `M2` depends on `M0` and can run **in parallel with
+M1**. `M3` is the final gate and depends on M1 + M2.
+
+```
+        ┌──────────────┐
+M0 ────►│ M1 (conform) │────┐
+  │     └──────────────┘    ▼
+  │                      ┌───────────────┐
+  └────►┌──────────────┐ │ M3 (green gate)│
+        │ M2 (removal) │►┘ └───────────────┘
+        └──────────────┘
+```
+
+---
+
+## 5. Milestones & epics
+
+### M0 — Green baseline (`green-baseline`)
+
+**Goal:** Eliminate the 6 Hardhat failures **and** the 1 Foundry fuzz failure, establish
+the shared fixtures that prevent recurrence, and repair the Foundry false-greens — leaving
+both `npx hardhat test` and `yarn forge:test` at 0 failing.
+
+**Exit criteria:** All 7 originally-failing tests pass or are properly retired; the two
+Foundry false-green negative tests fail-for-the-right-reason; bridge constants come from
+one shared module per runner; both suites green (Foundry run against a live `anvil`).
+
+| Epic | Title | Summary | Owner | Impact |
+|---|---|---|---|---|
+| M0-E1 | `fix-gas-test-bridgeout` | Update `test/gas/withdraw-limiter-gas-comparison.test.ts:205` (the 5 failing bin-count cases) to the 5-arg `bridgeOut(amount, id, destChainID, sgnsDestination, destinationYOdd)` form. | Engineer | High |
+| M0-E2 | `retire-openescrow-test` | Replace the commented-out `GeniusOwnershipFacet` "maintain state across ownership transfer" test with an escrow-free state-persistence assertion (or delete with a written reason). No commented test left behind. | Engineer | High |
+| M0-E3 | `shared-bridge-fixtures` | Hoist `SGNS_DESTINATION`, `SGNS_DESTINATION_Y_ODD`, canonical `destChainID`, `GNUS_TOKEN_ID` into a shared test helper; refactor `GNUSBridgeEnhanced.test.ts` + gas test to import it. (Foundry mirror: replace the 64-byte `bytes TEST_SGNS_DEST` in `GeniusDiamondTestBase.sol` with a `bytes32` X + `bool` Y-parity.) | Engineer | High |
+| M0-E4 | `fix-foundry-fuzz-bridgeout` | Migrate `test/foundry/fuzz/BridgeFuzz.t.sol` from the obsolete `bridgeOut(uint256,uint256,uint256,bytes)` selector to `bridgeOut(uint256,uint256,uint256,bytes32,bool)`. Fixes the `testFuzz_bridgeAmountEdgeCases` failure, repairs the two **false-green** negative tests (currently revert only because the selector is missing), and removes the now-obsolete `test_RevertWhen_InvalidDestinationKeyLength` (`bytes32` is fixed-length). | Engineer | High |
+
+### M1 — Bridge-design conformance (`bridge-conformance`)
+
+**Goal:** Ensure the suite *verifies* the new contract semantics, not merely that calls
+compile.
+
+**Exit criteria:** Full-field `BridgeOutInitiated` assertions; destination-key edge cases
+covered; guard reverts covered.
+
+| Epic | Title | Summary | Owner | Impact |
+|---|---|---|---|---|
+| M1-E1 | `event-arg-assertions` | Audit all `bridgeOut` specs (Hardhat **and** Foundry); assert `BridgeOutInitiated` with all 7 args incl. `srcChainID` from storage, `sgnsDestination`, `destinationYOdd`. Upgrade `emit`-only checks to `withArgs`; in Foundry use `vm.expectEmit`. | Engineer | High |
+| M1-E2 | `destination-key-coverage` | Add cases for X = zero, X = max `bytes32`, and both Y-parity values; assert the contract forwards the opaque key faithfully (no on-chain curve validation). | Engineer | Medium |
+| M1-E3 | `bridge-guard-coverage` | Cover the three reverts (`Token not created.`, `Insufficient tokens.`, `Cannot bridge to same chain`) and burn-then-emit ordering — asserting the **specific** revert reason (closes the Foundry false-green class where a missing selector masqueraded as a guard rejection). | Engineer | Medium |
+
+### M2 — Removal & submodule coverage (`removal-submodule`)
+
+**Goal:** Lock in the GeniusAI/OpenEscrow removal and DiamondInitFacet submodule change
+with positive and negative coverage.
+
+**Exit criteria:** Negative test for absent `OpenEscrow` selector; diamond-init tests
+reflect the current facet set (WithdrawLimiter present, GeniusAI absent).
+
+| Epic | Title | Summary | Owner | Impact |
+|---|---|---|---|---|
+| M2-E1 | `openescrow-removal-coverage` | Assert no `OpenEscrow`/GeniusAI selector is wired into the diamond (guards re-introduction). Remove any dangling references. | Engineer | Medium |
+| M2-E2 | `diamond-init-coverage` | Verify `DiamondInitFacet` init wiring against the new submodule config (WithdrawLimiter registered; `chainID`/`bridgeFee` defaults). Confirm submodule pointer (`diamonds/GeniusDiamond`) is intentional. | Engineer + **Owner** (pointer) | Medium |
+
+### M3 — Zero-debt green gate (`green-gate`)
+
+**Goal:** Resolve remaining pending tests and lock the green state.
+
+**Exit criteria:** 0 failing, 0 undocumented pending; final full-suite run recorded.
+
+| Epic | Title | Summary | Owner | Impact |
+|---|---|---|---|---|
+| M3-E1 | `resolve-rpc-pending` | Resolve `test/integration/rpc/rpc-deployment.test.ts` skips (`this.skip()` @19, `it.skip` @71): rewrite to run, or delete with a written reason. | Engineer | Medium |
+| M3-E2 | `resolve-template-skip` | Resolve the `it.skip` in `test/utils/test-template.ts:163` (template placeholder — likely keep with documented reason or remove from active runs). | Engineer | Low |
+| M3-E3 | `full-suite-green-gate` | Final `npx hardhat test` **and** `yarn clean-compile && yarn forge:test` (against a running `anvil`) both at 0 failing; record pass counts; confirm CI runs **both** runners (with `anvil` provisioned). | Engineer + **Owner** (merge) | High |
+
+---
+
+## 6. Cross-cutting workstreams
+
+- **Change log:** maintain `CHANGELOG.md` per epic dir as tests are edited.
+- **Contract-bug escalation:** any failure tracing to a contract (not a test) defect is
+  logged and escalated to the Owner — never silently patched in the test.
+- **Suite-health tracking:** record passing/failing/pending counts at each milestone
+  boundary. Baselines — **Hardhat:** 366 passing, 2 pending, 6 failing; **Foundry:** 216
+  passed, 1 failed, 1 skipped (218 total).
+- **Foundry environment:** `yarn forge:test` requires a running **`anvil`** instance (and
+  `yarn clean-compile` first). Document the exact local + CI invocation so contributors
+  reproduce the run; this is a prerequisite for every Foundry-touching epic and the M3 gate.
+- **Review:** each milestone's test diffs reviewed before the next begins.
+
+---
+
+## 7. Dependencies & sequencing rules
+
+- **M0 first** — everything depends on a green baseline and the shared fixtures (M0-E3).
+- **M1 ∥ M2** — both depend only on M0 and may proceed in parallel.
+- **M3 last** — depends on M1 + M2; it is the final gate.
+- **Blocking owner tasks:**
+  - **M2-E2 / M3-E3:** committing the `diamonds/GeniusDiamond` **submodule pointer** and
+    any **merge/push** of `feature/bridge-out-initiated` are Owner-only and block project
+    sign-off until done.
+
+---
+
+## 8. Risk register (plan-level)
+
+| Risk | Likelihood | Impact | Mitigation | Owner |
+|---|---|---|---|---|
+| A failure actually signals a contract bug, not a test gap | Low | High | Escalation rule (§6); never weaken a test to pass | Owner |
+| Submodule pointer drifts / not committed | Medium | Medium | M2-E2 asserts facet set; Owner commits pointer explicitly | Owner |
+| Constant drift recurs across files | Medium | Medium | M0-E3 single shared fixture | Engineer |
+| Partial event assertions hide field regressions | Medium | Medium | M1-E1 enforces full `withArgs` | Engineer |
+| False-greens: tests pass only because a stale selector reverts (Foundry `assertFalse(success)`) | High (already present) | High | M0-E4 + M1-E3 assert the *specific* revert reason, not bare failure | Engineer |
+| Foundry suite skipped/misreported because `anvil` isn't running | Medium | Medium | Document the `anvil` + `clean-compile` prerequisite; wire it into CI (M3-E3) | Engineer + Owner |
+| Pending tests silently re-accumulate | Low | Low | O5 zero-debt gate; documented reasons required | Engineer |
+
+---
+
+## 9. Rollback posture per milestone
+
+| Milestone | Primary rollback lever |
+|---|---|
+| M0 | Revert test-file commits; suite returns to known 6-failing baseline. |
+| M1 | Revert conformance commits; M0 green state retained. |
+| M2 | Revert coverage commits; **do not** revert submodule pointer (Owner-controlled). |
+| M3 | Revert pending-test edits; suite remains green from M1/M2. |
+
+All milestones are test-only and fully revertible via git; no system/state changes occur.
+
+---
+
+## 10. Deliverables checklist (project-level)
+
+- [ ] M0: Hardhat gas test uses 5-arg `bridgeOut`; Foundry `BridgeFuzz.t.sol` migrated to the `bytes32,bool` selector (failing test fixed, false-greens repaired, obsolete length test removed); OpenEscrow test retired; shared fixtures in place per runner; both suites green.
+- [ ] M1: full-field `BridgeOutInitiated` assertions; destination-key + guard coverage.
+- [ ] M2: negative `OpenEscrow`-selector test; diamond-init facet-set coverage; submodule pointer confirmed.
+- [ ] M3: pending tests resolved; final `npx hardhat test` at 0 failing, 0 undocumented pending.
+- [ ] Suite-health counts recorded at each milestone boundary.
+- [ ] Companion design doc kept in sync with any clarified contract behavior.
+
+---
+
+## 11. Next step — breaking this out
+
+Expand the first milestone with `/breakout-milestone`. The pipeline fills this tree:
+
+```
+project/bridge-test-realignment/
+├── bridge-test-realignment-project-plan.md     ← this file (plan of record)
+├── bridge-test-realignment-architecture.md     ← companion design doc
+├── Milestone-00/                               ← M0 (green-baseline)
+│   ├── overview/
+│   │   └── milestone-01-green-baseline.md       ← /breakout-milestone (file # is 1-based)
+│   ├── Epic-01/                                 ← M0-E1 fix-gas-test-bridgeout
+│   │   ├── overview/e1-fix-gas-test-bridgeout.md ← /breakout-epics
+│   │   ├── prd-e1-fix-gas-test-bridgeout.md      ← /create-prd
+│   │   ├── tasks-e1-fix-gas-test-bridgeout.md    ← /generate-tasks
+│   │   └── CHANGELOG.md
+│   ├── Epic-02/ …                               ← M0-E2 retire-openescrow-test
+│   ├── Epic-03/ …                               ← M0-E3 shared-bridge-fixtures
+│   └── Epic-04/ …                               ← M0-E4 fix-foundry-fuzz-bridgeout
+├── Milestone-01/ …                             ← M1 (bridge-conformance)
+├── Milestone-02/ …                             ← M2 (removal-submodule)
+└── Milestone-03/ …                             ← M3 (green-gate)
+```
+
+Indexing: directory `Milestone-NN` is zero-padded to the `M<n>` id (`M0`→`Milestone-00`);
+the overview filename/H1 uses the 1-based human number (`M0`→`milestone-01-…`,
+"Milestone 1"). Epic dirs/files use the `E<m>` number (`M0-E1`→`Epic-01/overview/e1-<slug>.md`).
+
+**▶ Run `/breakout-milestone` for M0 (green-baseline) to continue.**

--- a/test/foundry/base/GeniusDiamondTestBase.sol
+++ b/test/foundry/base/GeniusDiamondTestBase.sol
@@ -6,6 +6,18 @@ import {DiamondDeployment} from "../helpers/DiamondDeployment.sol";
 import {Test} from "forge-std/Test.sol";
 import {console} from "forge-std/console.sol";
 
+/// @notice Minimal typed view of the diamond's current bridgeOut for Foundry tests,
+/// so calls can use vm.expectRevert / vm.expectEmit instead of low-level diamond.call.
+interface IGNUSBridgeOut {
+    function bridgeOut(
+        uint256 amount,
+        uint256 id,
+        uint256 destChainID,
+        bytes32 sgnsDestination,
+        bool destinationYOdd
+    ) external;
+}
+
 /**
  * @title GeniusDiamondTestBase
  * @notice Base contract for all GeniusDiamond fuzz and invariant tests
@@ -22,10 +34,9 @@ abstract contract GeniusDiamondTestBase is DiamondFuzzBase {
     bytes32 public constant SGNS_DESTINATION = bytes32(uint256(0x1234));
     // Parity of the destination key's Y component (false = even). Mirrors SGNS_DESTINATION_Y_ODD.
     bool public constant SGNS_DESTINATION_Y_ODD = false;
-
-    // DEPRECATED: 64-byte `bytes` destination from the interim bridgeOut(...,bytes) signature.
-    // TODO(M0-E4): remove once BridgeFuzz.t.sol is migrated to the bytes32+bool selector.
-    bytes public constant TEST_SGNS_DEST = hex"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    // Canonical destination chain id (Polygon). Mirrors DEST_CHAIN_ID in bridge-fixtures.ts.
+    // The diamond's configured chainID defaults to 0 in tests, so 137 passes the same-chain guard.
+    uint256 public constant DEST_CHAIN_ID = 137;
 
     // ========================================
     // Role Constants (from GeniusAccessControl)

--- a/test/foundry/base/GeniusDiamondTestBase.sol
+++ b/test/foundry/base/GeniusDiamondTestBase.sol
@@ -14,7 +14,17 @@ import {console} from "forge-std/console.sol";
  * @dev All test contracts should inherit from this base
  */
 abstract contract GeniusDiamondTestBase is DiamondFuzzBase {
-    // 64-byte SuperGenius destination key (zero key for testing)
+    // ========================================
+    // Bridge Constants (paired with test/utils/bridge-fixtures.ts — keep in lockstep)
+    // ========================================
+    // 32-byte X component of the SuperGenius destination public key (0x1234 padded).
+    // Mirrors `SGNS_DESTINATION` in test/utils/bridge-fixtures.ts.
+    bytes32 public constant SGNS_DESTINATION = bytes32(uint256(0x1234));
+    // Parity of the destination key's Y component (false = even). Mirrors SGNS_DESTINATION_Y_ODD.
+    bool public constant SGNS_DESTINATION_Y_ODD = false;
+
+    // DEPRECATED: 64-byte `bytes` destination from the interim bridgeOut(...,bytes) signature.
+    // TODO(M0-E4): remove once BridgeFuzz.t.sol is migrated to the bytes32+bool selector.
     bytes public constant TEST_SGNS_DEST = hex"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
 
     // ========================================

--- a/test/foundry/fuzz/BridgeFuzz.t.sol
+++ b/test/foundry/fuzz/BridgeFuzz.t.sol
@@ -1,15 +1,27 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import {GeniusDiamondTestBase} from "../base/GeniusDiamondTestBase.sol";
+import {GeniusDiamondTestBase, IGNUSBridgeOut} from "../base/GeniusDiamondTestBase.sol";
 import {console} from "forge-std/console.sol";
 
 /**
  * @title BridgeFuzz
  * @notice Fuzz tests for bridge operations
- * @dev Tests bridge deposits and withdrawals with random parameters
+ * @dev Exercises the current bridgeOut(uint256,uint256,uint256,bytes32,bool) signature via a
+ *      typed interface so assertions check real on-chain effects and specific revert reasons.
  */
 contract BridgeFuzz is GeniusDiamondTestBase {
+    /// @dev Mirror of GNUSBridge.BridgeOutInitiated for vm.expectEmit.
+    event BridgeOutInitiated(
+        address indexed sender,
+        uint256 id,
+        uint256 amount,
+        uint256 srcChainID,
+        uint256 destChainID,
+        bytes32 sgnsDestination,
+        bool destinationYOdd
+    );
+
     /**
      * @notice Setup for Bridge fuzz tests
      */
@@ -22,7 +34,7 @@ contract BridgeFuzz is GeniusDiamondTestBase {
     }
 
     /**
-     * @notice Fuzz test: Bridge deposit with random amounts
+     * @notice Fuzz test: a valid bridgeOut burns the sender's balance and emits BridgeOutInitiated.
      * @param amount Amount to bridge
      */
     function testFuzz_bridgeDeposit(uint256 amount) public {
@@ -33,114 +45,76 @@ contract BridgeFuzz is GeniusDiamondTestBase {
             _mintGNUS(address(this), amount - balance + 100 ether);
         }
 
-        // Try bridge deposit (function signature may vary)
-        bytes memory callData = abi.encodeWithSignature(
-            "bridgeOut(uint256,uint256,uint256,bytes)",
+        uint256 balanceBefore = _getGNUSBalance(address(this));
+
+        // Expect the bridge-out event (check indexed sender topic; full arg matching is M1-E1).
+        vm.expectEmit(true, false, false, false, diamond);
+        emit BridgeOutInitiated(
+            address(this),
+            GNUS_TOKEN_ID,
+            amount,
+            0, // srcChainID (configured chainID defaults to 0 in tests)
+            DEST_CHAIN_ID,
+            SGNS_DESTINATION,
+            SGNS_DESTINATION_Y_ODD
+        );
+        IGNUSBridgeOut(diamond).bridgeOut(
             amount,
             GNUS_TOKEN_ID,
-            1, // destination chain ID
-            TEST_SGNS_DEST
+            DEST_CHAIN_ID,
+            SGNS_DESTINATION,
+            SGNS_DESTINATION_Y_ODD
         );
 
-        (bool success, ) = diamond.call(callData);
-
-        if (success) {
-            console.log("[OK] Bridge deposit succeeded");
-        } else {
-            console.log("[OK] Bridge deposit tested");
-        }
+        // The bridged amount must be burned from the sender (bridgeFee defaults to 0).
+        assertEq(
+            _getGNUSBalance(address(this)),
+            balanceBefore - amount,
+            "bridgeOut must burn the bridged amount"
+        );
     }
 
     /**
-     * @notice Fuzz test: Bridge with insufficient balance
+     * @notice Fuzz test: bridging more than the balance reverts with "Insufficient tokens.".
      * @param excessAmount Amount exceeding balance
      */
     function testFuzz_RevertWhen_depositExceedsBalance(uint256 excessAmount) public {
         uint256 balance = _getGNUSBalance(address(this));
         vm.assume(excessAmount > balance && excessAmount < type(uint256).max - 1000 ether);
 
-        bytes memory callData = abi.encodeWithSignature(
-            "bridgeOut(uint256,uint256,uint256,bytes)",
+        vm.expectRevert("Insufficient tokens.");
+        IGNUSBridgeOut(diamond).bridgeOut(
             excessAmount,
             GNUS_TOKEN_ID,
-            1,
-            TEST_SGNS_DEST
+            DEST_CHAIN_ID,
+            SGNS_DESTINATION,
+            SGNS_DESTINATION_Y_ODD
         );
 
-        (bool success, ) = diamond.call(callData);
-        assertFalse(success, "Excess bridge should fail");
-
-        console.log("[OK] Excess bridge deposit rejected");
+        console.log("[OK] Excess bridge deposit rejected with the expected reason");
     }
 
     /**
-     * @notice Fuzz test: Bridge amount edge cases
-     * @param amount Random amount including zero and max
+     * @notice Fuzz test: any valid bounded amount (with sufficient balance) bridges successfully.
+     * @param amount Random amount
      */
     function testFuzz_bridgeAmountEdgeCases(uint256 amount) public {
-        // Test with various amounts
-        if (amount == 0) {
-            console.log("[OK] Zero amount tested");
-            return;
-        }
-
         amount = _boundUint256(amount, 1, 10000 ether);
 
+        // Ensure the sender holds at least `amount` so the bridge can succeed.
         uint256 balance = _getGNUSBalance(address(this));
         if (balance < amount) {
-            amount = balance;
+            _mintGNUS(address(this), amount - balance);
         }
 
-        if (amount > 0) {
-            bytes memory callData = abi.encodeWithSignature(
-                "bridgeOut(uint256,uint256,uint256,bytes)",
-                amount,
-                GNUS_TOKEN_ID,
-                1,
-                TEST_SGNS_DEST
-            );
-
-            // Attempt bridge
-            (bool success, ) = diamond.call(callData);
-            assertTrue(success, "Bridge should succeed for valid amount");
-        }
-
-        console.log("[OK] Edge case tested");
-    }
-
-    /**
-     * @notice Test: bridgeOut reverts with wrong-length destination key
-     */
-    function test_RevertWhen_InvalidDestinationKeyLength() public {
-        uint256 amount = 100 ether;
-        uint256 balance = _getGNUSBalance(address(this));
-        if (balance < amount) {
-            _mintGNUS(address(this), amount - balance + 100 ether);
-        }
-
-        // 32-byte key (too short)
-        bytes memory shortKey = hex"0000000000000000000000000000000000000000000000000000000000000000";
-        bytes memory callData = abi.encodeWithSignature(
-            "bridgeOut(uint256,uint256,uint256,bytes)",
+        IGNUSBridgeOut(diamond).bridgeOut(
             amount,
             GNUS_TOKEN_ID,
-            1,
-            shortKey
+            DEST_CHAIN_ID,
+            SGNS_DESTINATION,
+            SGNS_DESTINATION_Y_ODD
         );
-        (bool success, ) = diamond.call(callData);
-        assertFalse(success, "Should revert with 32-byte key");
 
-        // empty key
-        callData = abi.encodeWithSignature(
-            "bridgeOut(uint256,uint256,uint256,bytes)",
-            amount,
-            GNUS_TOKEN_ID,
-            1,
-            new bytes(0)
-        );
-        (success, ) = diamond.call(callData);
-        assertFalse(success, "Should revert with empty key");
-
-        console.log("[OK] Invalid destination key length rejected");
+        console.log("[OK] Edge case bridged successfully");
     }
 }

--- a/test/foundry/handlers/GeniusDiamondHandler.sol
+++ b/test/foundry/handlers/GeniusDiamondHandler.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import {GeniusDiamondTestBase} from "../base/GeniusDiamondTestBase.sol";
+import {GeniusDiamondTestBase, IGNUSBridgeOut} from "../base/GeniusDiamondTestBase.sol";
 import {console} from "forge-std/console.sol";
 
 /**
@@ -267,21 +267,20 @@ contract GeniusDiamondHandler is GeniusDiamondTestBase {
 
         amount = _boundUint256(amount, 1 ether, balance);
 
-        bytes memory callData = abi.encodeWithSignature(
-            "bridgeOut(uint256,uint256,uint256,bytes)",
-            amount,
-            GNUS_TOKEN_ID,
-            1, // destination chain
-            TEST_SGNS_DEST
-        );
-
+        // Typed bridgeOut; success-gated ghost-counter semantics preserved via try/catch.
         vm.prank(currentActor);
-        (bool success, ) = diamond.call(callData);
-
-        if (success) {
+        try
+            IGNUSBridgeOut(diamond).bridgeOut(
+                amount,
+                GNUS_TOKEN_ID,
+                DEST_CHAIN_ID,
+                SGNS_DESTINATION,
+                SGNS_DESTINATION_Y_ODD
+            )
+        {
             ghost_totalBridgeDeposits++;
             calls_bridgeDeposit++;
-        }
+        } catch {}
 
         console.log("[HANDLER] Bridge Deposit:", amount);
     }

--- a/test/gas/withdraw-limiter-gas-comparison.test.ts
+++ b/test/gas/withdraw-limiter-gas-comparison.test.ts
@@ -19,6 +19,11 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import hre, { ethers } from 'hardhat';
 import type { GeniusDiamond } from '../../diamond-typechain-types';
 import { toWei } from '../../scripts/utils/helpers';
+import {
+	SGNS_DESTINATION,
+	SGNS_DESTINATION_Y_ODD,
+	DEST_CHAIN_ID,
+} from '../utils/bridge-fixtures';
 
 interface GasResult {
 	binCount: number;
@@ -202,7 +207,13 @@ describe('Withdraw Limiter Gas Usage Comparison', function () {
 						// Note: bridgeOut doesn't trigger limiter, but we measure it for comparison
 						const tx = await geniusDiamond
 							.connect(user1)
-							.bridgeOut(gnusAmount, GNUS_TOKEN_ID, 137);
+							.bridgeOut(
+								gnusAmount,
+								GNUS_TOKEN_ID,
+								DEST_CHAIN_ID,
+								SGNS_DESTINATION,
+								SGNS_DESTINATION_Y_ODD,
+							);
 						const receipt = await tx.wait();
 
 						recordGas(

--- a/test/unit/GNUSBridgeEnhanced.test.ts
+++ b/test/unit/GNUSBridgeEnhanced.test.ts
@@ -7,6 +7,11 @@ import { expect } from 'chai';
 import hre, { ethers } from 'hardhat';
 import { GeniusDiamond } from '../../diamond-typechain-types';
 import { toWei } from '../../scripts/utils/helpers';
+import {
+	SGNS_DESTINATION,
+	SGNS_DESTINATION_Y_ODD,
+	DEST_CHAIN_ID,
+} from '../utils/bridge-fixtures';
 
 describe('GNUSBridge Enhanced Tests', function () {
 	let geniusDiamond: GeniusDiamond;
@@ -16,11 +21,6 @@ describe('GNUSBridge Enhanced Tests', function () {
 	let user3: SignerWithAddress;
 	let initialSnapshotId: string;
 	let snapshotId: string;
-
-	// 32-byte X component of the SuperGenius destination public key (not an Ethereum address)
-	const SGNS_DESTINATION = ethers.zeroPadValue('0x1234', 32);
-	// Y-component parity for SGNS_DESTINATION (false = even)
-	const SGNS_DESTINATION_Y_ODD = false;
 
 	before(async function () {
 		const config = {
@@ -410,12 +410,22 @@ describe('GNUSBridge Enhanced Tests', function () {
 			await geniusDiamond.setChainID(1); // Ethereum mainnet
 
 			// Bridge out to chain 137 (Polygon)
-			const tx = await geniusDiamond.connect(user1).bridgeOut(50, 1, 137, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD);
+			const tx = await geniusDiamond
+				.connect(user1)
+				.bridgeOut(50, 1, DEST_CHAIN_ID, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD);
 
 			// Check event
 			await expect(tx)
 				.to.emit(geniusDiamond, 'BridgeOutInitiated')
-				.withArgs(user1.address, 1, 50, 1, 137, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD);
+				.withArgs(
+					user1.address,
+					1,
+					50,
+					1,
+					DEST_CHAIN_ID,
+					SGNS_DESTINATION,
+					SGNS_DESTINATION_Y_ODD,
+				);
 
 			// Check balance decreased
 			const balance = await geniusDiamond['balanceOf(address,uint256)'](user1.address, 1);
@@ -424,7 +434,15 @@ describe('GNUSBridge Enhanced Tests', function () {
 
 		it('should revert bridgeOut if token not created', async function () {
 			await expect(
-				geniusDiamond.connect(user1).bridgeOut(100, toWei(999), 137, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD),
+				geniusDiamond
+					.connect(user1)
+					.bridgeOut(
+						100,
+						toWei(999),
+						DEST_CHAIN_ID,
+						SGNS_DESTINATION,
+						SGNS_DESTINATION_Y_ODD,
+					),
 			).to.be.revertedWith('Token not created.');
 		});
 
@@ -441,10 +459,10 @@ describe('GNUSBridge Enhanced Tests', function () {
 
 			// Try to bridge without having any tokens
 			await expect(
-				geniusDiamond.connect(user1).bridgeOut(100, 1, 137, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD),
-			).to.be.revertedWith(
-				'Insufficient tokens.',
-			);
+				geniusDiamond
+					.connect(user1)
+					.bridgeOut(100, 1, DEST_CHAIN_ID, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD),
+			).to.be.revertedWith('Insufficient tokens.');
 		});
 
 		it('should handle bridgeOut for GNUS tokens', async function () {
@@ -457,7 +475,13 @@ describe('GNUSBridge Enhanced Tests', function () {
 			// Bridge out GNUS tokens
 			const tx = await geniusDiamond
 				.connect(user1)
-				.bridgeOut(toWei(500), toWei(0), 137, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD);
+				.bridgeOut(
+					toWei(500),
+					toWei(0),
+					DEST_CHAIN_ID,
+					SGNS_DESTINATION,
+					SGNS_DESTINATION_Y_ODD,
+				);
 
 			// Check event
 			await expect(tx).to.emit(geniusDiamond, 'BridgeOutInitiated');

--- a/test/unit/GNUSBridgeEnhanced.test.ts
+++ b/test/unit/GNUSBridgeEnhanced.test.ts
@@ -17,6 +17,11 @@ describe('GNUSBridge Enhanced Tests', function () {
 	let initialSnapshotId: string;
 	let snapshotId: string;
 
+	// 32-byte X component of the SuperGenius destination public key (not an Ethereum address)
+	const SGNS_DESTINATION = ethers.zeroPadValue('0x1234', 32);
+	// Y-component parity for SGNS_DESTINATION (false = even)
+	const SGNS_DESTINATION_Y_ODD = false;
+
 	before(async function () {
 		const config = {
 			diamondName: 'GeniusDiamond',
@@ -387,7 +392,7 @@ describe('GNUSBridge Enhanced Tests', function () {
 	});
 
 	describe('Bridge Out Functionality', function () {
-		it('should emit BridgeSourceBurned event correctly', async function () {
+		it('should emit BridgeOutInitiated event correctly', async function () {
 			// Create NFT
 			await geniusDiamond.createNFT(
 				0, // parent = GNUS (tokenId 0)
@@ -405,12 +410,12 @@ describe('GNUSBridge Enhanced Tests', function () {
 			await geniusDiamond.setChainID(1); // Ethereum mainnet
 
 			// Bridge out to chain 137 (Polygon)
-			const tx = await geniusDiamond.connect(user1).bridgeOut(50, 1, 137);
+			const tx = await geniusDiamond.connect(user1).bridgeOut(50, 1, 137, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD);
 
 			// Check event
 			await expect(tx)
-				.to.emit(geniusDiamond, 'BridgeSourceBurned')
-				.withArgs(user1.address, 1, 50, 1, 137);
+				.to.emit(geniusDiamond, 'BridgeOutInitiated')
+				.withArgs(user1.address, 1, 50, 1, 137, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD);
 
 			// Check balance decreased
 			const balance = await geniusDiamond['balanceOf(address,uint256)'](user1.address, 1);
@@ -419,7 +424,7 @@ describe('GNUSBridge Enhanced Tests', function () {
 
 		it('should revert bridgeOut if token not created', async function () {
 			await expect(
-				geniusDiamond.connect(user1).bridgeOut(100, toWei(999), 137),
+				geniusDiamond.connect(user1).bridgeOut(100, toWei(999), 137, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD),
 			).to.be.revertedWith('Token not created.');
 		});
 
@@ -435,7 +440,9 @@ describe('GNUSBridge Enhanced Tests', function () {
 			);
 
 			// Try to bridge without having any tokens
-			await expect(geniusDiamond.connect(user1).bridgeOut(100, 1, 137)).to.be.revertedWith(
+			await expect(
+				geniusDiamond.connect(user1).bridgeOut(100, 1, 137, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD),
+			).to.be.revertedWith(
 				'Insufficient tokens.',
 			);
 		});
@@ -448,10 +455,12 @@ describe('GNUSBridge Enhanced Tests', function () {
 			await geniusDiamond.setChainID(1);
 
 			// Bridge out GNUS tokens
-			const tx = await geniusDiamond.connect(user1).bridgeOut(toWei(500), toWei(0), 137);
+			const tx = await geniusDiamond
+				.connect(user1)
+				.bridgeOut(toWei(500), toWei(0), 137, SGNS_DESTINATION, SGNS_DESTINATION_Y_ODD);
 
 			// Check event
-			await expect(tx).to.emit(geniusDiamond, 'BridgeSourceBurned');
+			await expect(tx).to.emit(geniusDiamond, 'BridgeOutInitiated');
 
 			// Check balance decreased
 			const balance = await geniusDiamond['balanceOf(address)'](user1.address);

--- a/test/unit/GeniusOwnershipFacet.test.ts
+++ b/test/unit/GeniusOwnershipFacet.test.ts
@@ -1,7 +1,7 @@
 import { Diamond } from '@diamondslab/diamonds';
 import {
-    LocalDiamondDeployer,
-    loadDiamondContract,
+	LocalDiamondDeployer,
+	loadDiamondContract,
 } from '@diamondslab/hardhat-diamonds/dist/utils';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
@@ -257,22 +257,29 @@ describe('GeniusOwnershipFacet', function () {
 		});
 
 		it('should maintain contract state across ownership transfer', async function () {
-			// Open an escrow before transfer
-			const uuid = hre.ethers.encodeBytes32String('test-uuid');
-			const amount = hre.ethers.parseEther('1.0');
-			await geniusDiamond.connect(user1).OpenEscrow(uuid, { value: amount });
+			// Establish persistent state without the removed escrow feature:
+			// a token balance and a granted role should both survive an ownership transfer,
+			// since the diamond owner (LibDiamond contractOwner) is separate from AccessControl roles.
+			await geniusDiamond['mint(address,uint256)'](
+				user1.address,
+				hre.ethers.parseEther('100'),
+			);
+			const role = await geniusDiamond.MINTER_ROLE();
+			await geniusDiamond.connect(owner).grantRole(role, user2.address);
 
-			// Get contract balance before transfer
-			const balanceBefore = await hre.ethers.provider.getBalance(diamondAddress);
+			// Record pre-transfer state
+			const balanceBefore = await geniusDiamond['balanceOf(address)'](user1.address);
+			expect(await geniusDiamond.hasRole(role, user2.address)).to.be.true;
 
 			// Transfer ownership
 			await geniusDiamond.connect(owner).transferOwnership(user1.address);
+			expect(await geniusDiamond.owner()).to.equal(user1.address);
 
-			// Get contract balance after transfer
-			const balanceAfter = await hre.ethers.provider.getBalance(diamondAddress);
-
-			// Balance should remain unchanged
-			expect(balanceAfter).to.equal(balanceBefore);
+			// State should be unchanged after the transfer
+			expect(await geniusDiamond['balanceOf(address)'](user1.address)).to.equal(
+				balanceBefore,
+			);
+			expect(await geniusDiamond.hasRole(role, user2.address)).to.be.true;
 		});
 
 		it('should allow ownership queries from any address', async function () {

--- a/test/utils/bridge-fixtures.ts
+++ b/test/utils/bridge-fixtures.ts
@@ -1,0 +1,28 @@
+import { ethers } from 'hardhat';
+
+/**
+ * Shared bridge test fixtures (Hardhat).
+ *
+ * Single source of truth for the constants used by bridge-related Hardhat tests
+ * (`bridgeOut` / `BridgeOutInitiated`). Import these instead of redefining literals
+ * per file — a future `bridgeOut` signature or value change should be a one-file edit.
+ *
+ * NOTE: `SGNS_DESTINATION` (the 32-byte X component) MUST stay in lockstep with the
+ * matching `bytes32 SGNS_DESTINATION` constant in
+ * `test/foundry/base/GeniusDiamondTestBase.sol` (both encode `0x1234` padded to 32 bytes).
+ */
+
+/** 32-byte X component of the SuperGenius destination public key (not an Ethereum address). */
+export const SGNS_DESTINATION = ethers.zeroPadValue('0x1234', 32);
+
+/** Parity of the destination key's Y component (false = even, true = odd). */
+export const SGNS_DESTINATION_Y_ODD = false;
+
+/**
+ * Canonical destination chain id for bridge tests (Polygon).
+ * Guaranteed `!=` the local Hardhat/anvil chain id, so `bridgeOut`'s same-chain guard passes.
+ */
+export const DEST_CHAIN_ID = 137;
+
+/** Re-exported so bridge specs get every constant from one import (value defined in scripts/common). */
+export { GNUS_TOKEN_ID } from '../../scripts/common';


### PR DESCRIPTION
## Summary

Updates the GNUSBridge test suite to match the contract changes in gnus-ai-contracts#1, and bumps the contracts/gnus-ai submodule pointer.

- Update bridgeOut calls to the new 5-arg signature (amount, id, destChainID, bytes32 sgnsDestination, bool destinationYOdd).
- Rename the expected event BridgeSourceBurned -> BridgeOutInitiated and assert sgnsDestination + destinationYOdd.
- Bump contracts/gnus-ai submodule to the new GNUSBridge.sol commit.

## Test result

npx hardhat test test/unit/GNUSBridgeEnhanced.test.ts -> 31 passing, including all 4 Bridge Out cases.

## Stacked

Depends on gnus-ai-contracts#1. Merge that first, then this.