### PR TITLE
test(08.1): skip stale pre-upgrade baseline via on-chain version; fix sepolia RPC alias

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -65,7 +65,7 @@ wrap_comments = true
 # RPC endpoints for forking
 [rpc_endpoints]
 mainnet = "${MAINNET_RPC_URL}"
-sepolia = "${SEPOLIA_RPC_URL}"
+sepolia = "${SEPOLIA_RPC}"
 hardhat = "http://localhost:${HARDHAT_PORT}"
 
 # Etherscan API keys for verification

--- a/test/foundry/unit/SafeSingleShotUpgrade.t.sol
+++ b/test/foundry/unit/SafeSingleShotUpgrade.t.sol
@@ -133,8 +133,25 @@ contract SafeSingleShotUpgradeTest is Test {
 
     // ── tests ────────────────────────────────────────────────
 
+    /// @notice Read-only view onto GNUSControl for the on-chain protocol version.
+    /// @dev selector 0x93420cf4 routes to the GNUSControl facet on the live diamond.
+    function _protocolVersion() internal view returns (uint256) {
+        (bool ok, bytes memory data) = DIAMOND.staticcall(abi.encodeWithSignature("protocolInfo()"));
+        require(ok, "protocolInfo() failed");
+        (, uint256 protocolVersion, ) = abi.decode(data, (uint256, uint256, uint256));
+        return protocolVersion;
+    }
+
     /// @notice Baseline: verify current Sepolia diamond state.
-    function test_SepoliaCurrentState() public view {
+    /// @dev These are PRE-upgrade (v2.5) expectations. If the live diamond has already
+    ///      been upgraded (protocolVersion >= 250), the GeniusAI/Escrow facets have been
+    ///      removed and this baseline is stale — skip rather than fail against the
+    ///      post-upgrade state. The v2.5 post-state is covered by
+    ///      test_SingleShotUpgradeFromArtifact on the anvil fork.
+    function test_SepoliaCurrentState() public {
+        if (_protocolVersion() >= 250) {
+            vm.skip(true, "diamond already at v2.5; pre-upgrade baseline is stale");
+        }
         assertEq(_facetCount(), 12, "Sepolia diamond: 12 facets");
         assertEq(_getSelectors(GENIUS_AI_SHELL).length, 2, "GeniusAI shell: 2 selectors");
         assertEq(_getSelectors(ESCROW_FACET).length, 7, "Escrow facet: 7 selectors");


### PR DESCRIPTION
## Summary

Fixes for the Phase 08.1 Sepolia fork tests (`SafeDiamondCutTest`, `SafeSingleShotUpgradeTest`).

- **`foundry.toml`** — point the `sepolia` `rpc_endpoints` alias at `${SEPOLIA_RPC}` (project standard) instead of the unset `${SEPOLIA_RPC_URL}`, so `forge test --fork-url sepolia` resolves.
- **`SafeSingleShotUpgrade.test_SepoliaCurrentState`** — read the on-chain `GNUSControl.protocolInfo()` version and `vm.skip` the pre-upgrade (v2.5) facet baseline when the live diamond is already ≥ v2.5, instead of failing against the post-upgrade state. Added a `_protocolVersion()` helper.

## Context

These are **manual Sepolia fork tests** (D-01). They are not run by the default `forge:test` (which targets `--network localhost`) nor by any CI. They require an explicit `--fork-url` against a live Sepolia endpoint. The `test_SepoliaCurrentState` baseline asserted pre-upgrade state (GeniusAI shell: 2 selectors, Escrow: 7 selectors); the v2.5 upgrade has since executed on Sepolia (live `protocolInfo().protocolVersion == 250`), so the baseline is now stale and would permanently fail against latest.

## Verification

Against live Sepolia (`--fork-url sepolia`):
- `SafeDiamondCutTest`: **3/3 pass** (Safe multisig diamondCut path end-to-end)
- `SafeSingleShotUpgradeTest`: **0 fail / 2 skip** — baseline skips cleanly ("diamond already at v2.5; pre-upgrade baseline is stale"), artifact test self-skips (`ENCODED_CUT_PATH` unset, anvil-only)

---

@codex review
